### PR TITLE
Make aspectj work in eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.8</version>
+        <version>1.10</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
@@ -126,12 +126,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.8.9</version>
+            <version>1.8.10</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.8.9</version>
+            <version>1.8.10</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Use latest aspectj version that contains this fix
https://github.com/mojohaus/aspectj-maven-plugin/issues/18
to make it work in eclipse.