### PR TITLE
Fix aspectj version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,12 +126,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.8.10</version>
+            <version>1.8.9</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.8.10</version>
+            <version>1.8.9</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Fixes this warning:
[WARNING] bad version number found in ~\.m2\repository\org\aspectj\aspectjrt\1.8.9\aspectjrt-1.8.9.jar expected 1.8.10 found 1.8.9

aspectj-maven-plugin 1.8.10 matches these versions:
aspectjrt 1.8.9
aspectjtools 1.8.9
http://www.mojohaus.org/aspectj-maven-plugin/usage.html