### PR TITLE
RMB-17 Adjust path raml-util when copy apidocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,9 @@
                 <replace token="protocols: [ HTTPS ]" value="protocols: [ HTTP ]" dir="${basedir}/target/classes/apidocs/raml">
                   <include name="**/*.raml" />
                 </replace>
+                <replace token="../.." value="../raml-util" dir="${basedir}/target/classes/apidocs/raml">
+                  <include name="**/*.raml" />
+                </replace>
               </target>
             </configuration>
             <goals>


### PR DESCRIPTION
Following move of user-related RAML files to raml-util