### PR TITLE
Modusers 12

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "users",
-      "version": "10.0",
+      "version": "11.0",
       "handlers" : [
         {
           "methods": [ "GET" ],

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 11.0.0 2017-06-07
  * Replace user JSON property 'preferredContact' with 'preferredContactTypeId'
+ * Add array of addresses in user JSON property 'personal'
  * Change dependency to RMB v12.1.3
 
 ## 10.1.1 2017-05-26

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 11.0.0 2017-06-07
+ * Replace user JSON property 'preferredContact' with 'preferredContactTypeId'
+ * Change dependency to RMB v12.1.3
+
 ## 10.1.1 2017-05-26
  * Correct interface version in Module Descriptor
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>10.1.3-SNAPSHOT</version>
+  <version>11.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -366,7 +366,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <raml-module-builder.version>12.1.3-SNAPSHOT</raml-module-builder.version>
+    <raml-module-builder.version>12.1.3</raml-module-builder.version>
     <ramlfiles_path>${basedir}/raml-util/ramls/mod-users</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
     <postgresrunner.port>5434</postgresrunner.port>


### PR DESCRIPTION
Kurt, this is a merge of userdata schema changes from modusers-12 and modusers-15, so they can go simultaneously into v11.0.0 without a need for intermediate POM versions. 

Version is set to "11.0.0-SNAPSHOT" - that's what we need when initiating the mvn release process, right. 

"SNAPSHOT" has been removed from the RMB dep. 
