### PR TITLE
Include Descriptor.json files in Docker image root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV VERTICLE_HOME /usr/verticles
 
 # Copy your fat jar to the container
 COPY target/$VERTICLE_FILE $VERTICLE_HOME/module.jar
+COPY target/*Descriptor.json $VERTICLE_HOME/
 COPY docker/docker-entrypoint.sh $VERTICLE_HOME/docker-entrypoint.sh
 
 # Create user/group 'folio'


### PR DESCRIPTION
With the switch towards dynamically generated Descriptor files (ModuleDescriptor, DeploymentDescriptor, etc), it would be helpful to include the generated Descriptor files in the image built by docker.  This decouples the generated container from its generation, freeing users to pull pre-built images in lieu of forcing them to build from source.