### PR TITLE
update module descriptor for raml and json schema interface

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -117,32 +117,24 @@
       ]
     },
     {
-      "id": "_jsonSchema",
+      "id": "_jsonSchemas",
       "version": "1.0",
       "interfaceType" : "multiple",
       "handlers" : [
         {
           "methods" : [ "GET" ],
-          "pathPattern" : "/_/jsonSchema"
-        },
-        {
-          "methods" : [ "GET" ],
-          "pathPattern" : "/_/jsonSchema/{jsonSchemaName}"
+          "pathPattern" : "/_/jsonSchemas"
         }
       ]
     },
     {
-      "id": "_raml",
+      "id": "_ramls",
       "version": "1.0",
       "interfaceType" : "multiple",
       "handlers" : [
         {
           "methods" : [ "GET" ],
-          "pathPattern" : "/_/raml"
-        },
-        {
-          "methods" : [ "GET" ],
-          "pathPattern" : "/_/raml/{ramlName}"
+          "pathPattern" : "/_/ramls"
         }
       ]
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -117,6 +117,36 @@
       ]
     },
     {
+      "id": "_jsonSchema",
+      "version": "1.0",
+      "interfaceType" : "multiple",
+      "handlers" : [
+        {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/_/jsonSchema"
+        },
+        {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/_/jsonSchema/{jsonSchemaName}"
+        }
+      ]
+    },
+    {
+      "id": "_raml",
+      "version": "1.0",
+      "interfaceType" : "multiple",
+      "handlers" : [
+        {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/_/raml"
+        },
+        {
+          "methods" : [ "GET" ],
+          "pathPattern" : "/_/raml/{ramlName}"
+        }
+      ]
+    },
+    {
       "id": "_tenant",
       "version": "1.0",
       "interfaceType" : "system",

--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <raml-module-builder.version>23.0.0</raml-module-builder.version>
+    <raml-module-builder.version>23.1.1-SNAPSHOT</raml-module-builder.version>
     <vertx.version>3.5.1</vertx.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <postgresrunner.port>5434</postgresrunner.port>


### PR DESCRIPTION
Updated module descriptor to expose RAML and JSON schema multiple interface.

requires https://github.com/folio-org/raml/pull/111 and https://github.com/folio-org/raml-module-builder/pull/324