### PR TITLE
MODUSERS-106: add indexes to speed up user search

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -26,6 +26,48 @@
         {
           "fieldName" : "username",
           "tOps" : "ADD"
+        },
+        {
+          "fieldName" : "barcode",
+          "tOps" : "ADD"
+        }
+      ],
+      "ginIndex": [
+        {
+          "fieldName": "username",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "personal.firstName",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "personal.lastName",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "personal.email",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "barcode",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "externalSystemId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
         }
       ]
     },


### PR DESCRIPTION
Search user generates CQL like `query=(((username="cboerema*" or personal.firstName="cboerema*" or personal.lastName="cboerema*" or personal.email="cboerema*" or barcode="cboerema*" or id="cboerema*" or externalSystemId="cboerema*")) and active="true") sortby personal.lastName personal.firstName`. Currently the database schema does not have necessary index to speed up the query. This PR added those necessary indexes. Test in local and see the query time reduced from **1s to 3 ms**.