### PR TITLE
MODUSERS-125: add GIN index on id field to improve user search (sort by group) performance

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -34,6 +34,12 @@
       ],
       "ginIndex": [
         {
+          "fieldName": "id",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
           "fieldName": "username",
           "tOps": "ADD",
           "caseSensitive": false,


### PR DESCRIPTION
In MODUSERS-125, this API call 
```
/users?limit=30&offset=90&query=%28%28username%3D%22gunnarsson%2A%22%20or%20personal.firstName%3D%22gunnarsson%2A%22%20or%20personal.lastName%3D%22gunnarsson%2A%22%20or%20personal.email%3D%22gunnarsson%2A%22%20or%20barcode%3D%22gunnarsson%2A%22%20or%20id%3D%22gunnarsson%2A%22%20or%20externalSystemId%3D%22gunnarsson%2A%22%29%29%20sortby%20active%20patronGroup.group%2Fsort.descending is very slow. 
```
The generated query is like 
```
FROM fs00001000_mod_users.users_groups_view WHERE ((((((lower(f_unaccent(users_groups_view.jsonb->>'username')) ~ lower(f_unaccent('(^|[[:punct:]]|[[:space:]]|(?=[[:punct:]]|[[:space:]]))gunnarsson.*($|[[:punct:]]|[[:space:]]|(?<=[[:punct:]]|[[:space:]]))'))) OR (lower(f_unaccent(users_groups_view.jsonb->'personal'->>'firstName')) ~ lower(f_unaccent('(^|[[:punct:]]|[[:space:]]|(?=[[:punct:]]|[[:space:]]))gunnarsson.*($|[[:punct:]]|[[:space:]]|(?<=[[:punct:]]|[[:space:]]))')))) OR (lower(f_unaccent(users_groups_view.jsonb->'personal'->>'lastName')) ~ lower(f_unaccent('(^|[[:punct:]]|[[:space:]]|(?=[[:punct:]]|[[:space:]]))gunnarsson.*($|[[:punct:]]|[[:space:]]|(?<=[[:punct:]]|[[:space:]]))')))) OR (lower(f_unaccent(users_groups_view.jsonb->'personal'->>'email')) ~ lower(f_unaccent('(^|[[:punct:]]|[[:space:]]|(?=[[:punct:]]|[[:space:]]))gunnarsson.*($|[[:punct:]]|[[:space:]]|(?<=[[:punct:]]|[[:space:]]))')))) OR (lower(f_unaccent(users_groups_view.jsonb->>'barcode')) ~ lower(f_unaccent('(^|[[:punct:]]|[[:space:]]|(?=[[:punct:]]|[[:space:]]))gunnarsson.*($|[[:punct:]]|[[:space:]]|(?<=[[:punct:]]|[[:space:]]))')))) OR (lower(f_unaccent(users_groups_view.jsonb->>'id')) ~ lower(f_unaccent('(^|[[:punct:]]|[[:space:]]|(?=[[:punct:]]|[[:space:]]))gunnarsson.*($|[[:punct:]]|[[:space:]]|(?<=[[:punct:]]|[[:space:]]))')))) OR (lower(f_unaccent(users_groups_view.jsonb->>'externalSystemId')) ~ lower(f_unaccent('(^|[[:punct:]]|[[:space:]]|(?=[[:punct:]]|[[:space:]]))gunnarsson.*($|[[:punct:]]|[[:space:]]|(?<=[[:punct:]]|[[:space:]]))')));
```
The query analyze shows that there is sequential scan on the large user table and the execution time is 1549.206 ms. Adding a GIN index to json->>'id' reduced it to 12.942 ms.
