### PR TITLE
Add index to expirationDate

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -30,6 +30,12 @@
         {
           "fieldName" : "barcode",
           "tOps" : "ADD"
+        },
+        {
+          "fieldName" : "expirationDate",
+          "tOps" : "ADD",
+          "caseSensitive": true,
+          "removeAccents": false
         }
       ],
       "ginIndex": [


### PR DESCRIPTION
Every 30 seconds, mod-users kicks off a query like below. Adding an index on expirationDate field reduces the execution time from about **11.589 ms to 0.218 ms**.
```
WHERE (lower(f_unaccent(users.jsonb->>'active')) LIKE lower(f_unaccent('true'))) AND (users.jsonb->>'expirationDate' <'2019-06-06T16:51:39.827Z')
```
