### PR TITLE
MODUSERS-131: Update to RMB 26.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,11 +419,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <raml-module-builder.version>25.0.1</raml-module-builder.version>
+    <raml-module-builder.version>26.1.0</raml-module-builder.version>
     <vertx.version>3.5.4</vertx.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <postgresrunner.port>5434</postgresrunner.port>
-    <!-- Postgres port for Jenkins CI build environment https://issues.folio.org/browse/METADATA-10 -->
-    <postgres.port>5433</postgres.port>
   </properties>
 </project>

--- a/src/main/java/org/folio/rest/impl/UserGroupAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserGroupAPI.java
@@ -9,15 +9,12 @@ import org.folio.rest.jaxrs.model.Usergroup;
 import org.folio.rest.jaxrs.model.Usergroups;
 import org.folio.rest.jaxrs.resource.Groups;
 import org.folio.rest.persist.PgUtil;
-import org.folio.rest.tools.messages.Messages;
 import org.folio.rest.tools.utils.ValidationHelper;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 
 /**
  * @author shale
@@ -28,10 +25,6 @@ public class UserGroupAPI implements Groups {
   public static final String GROUP_TABLE = "groups";
   public static final String GROUP_USER_JOIN_TABLE = "groups_users";
   public static final String ID_FIELD_NAME = "id";
-
-  private static final String LOCATION_PREFIX = "/groups/";
-  private static final Logger log = LoggerFactory.getLogger(UserGroupAPI.class);
-  private final Messages messages = Messages.getInstance();
 
   @Validate
   @Override
@@ -94,7 +87,7 @@ public class UserGroupAPI implements Groups {
         PutGroupsByGroupIdResponse.class, asyncResultHandler);
   }
 
-  private boolean isDuplicate(String errorMessage) {
+  protected boolean isDuplicate(String errorMessage) {
     return errorMessage != null && errorMessage.contains("duplicate key value violates unique constraint");
   }
 }

--- a/src/main/java/org/folio/rest/impl/UserGroupAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserGroupAPI.java
@@ -1,30 +1,23 @@
 package org.folio.rest.impl;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.folio.rest.annotations.Validate;
-import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.jaxrs.model.Usergroup;
 import org.folio.rest.jaxrs.model.Usergroups;
 import org.folio.rest.jaxrs.resource.Groups;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.persist.Criteria.Criteria;
-import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PgUtil;
-import org.folio.rest.tools.messages.MessageConsts;
 import org.folio.rest.tools.messages.Messages;
-import org.folio.rest.utils.PostgresClientUtil;
-import org.folio.rest.utils.ValidationHelper;
+import org.folio.rest.tools.utils.ValidationHelper;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import java.util.UUID;
 
 /**
  * @author shale
@@ -57,34 +50,20 @@ public class UserGroupAPI implements Groups {
     Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
 
-    String id = entity.getId();
-    if (id == null) {
-      id = UUID.randomUUID().toString();
-      entity.setId(id);
-    }
-    PostgresClientUtil.getInstance(vertxContext, okapiHeaders).save(
-      GROUP_TABLE, id, entity, reply -> {
-        if (reply.succeeded()) {
-          String ret = reply.result();
-          entity.setId(ret);
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
-            PostGroupsResponse.respond201WithApplicationJson(entity,
-              PostGroupsResponse.headersFor201().withLocation(LOCATION_PREFIX + ret))));
-        } else {
-          log.error(reply.cause().getMessage(), reply.cause());
-          if (isDuplicate(reply.cause().getMessage())) {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+    PgUtil.post(GROUP_TABLE, entity, okapiHeaders, vertxContext, PostGroupsResponse.class, post -> {
+      try {
+        if (post.succeeded() && isDuplicate(post.result().getEntity().toString())) {
+          asyncResultHandler.handle(Future.succeededFuture(
               PostGroupsResponse.respond422WithApplicationJson(
                 ValidationHelper.createValidationErrorMessage(
                   "group", entity.getGroup(), "Group exists"))));
-          } else {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
-              PostGroupsResponse.respond500WithTextPlain(
-                messages.getMessage(lang,
-                  MessageConsts.InternalServerError))));
-          }
+          return;
         }
-      });
+        asyncResultHandler.handle(post);
+      } catch (Exception e) {
+        ValidationHelper.handleError(e, asyncResultHandler);
+      }
+    });
   }
 
   @Validate
@@ -92,33 +71,8 @@ public class UserGroupAPI implements Groups {
   public void getGroupsByGroupId(String groupId, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    // PgUtil.getById .. returns 500 where the below returns 404
-    Criterion c = new Criterion(
-      new Criteria().addField(ID_FIELD_NAME).setJSONB(false).setOperation("=").setVal(groupId));
-
-    PostgresClientUtil.getInstance(vertxContext, okapiHeaders).get(GROUP_TABLE, Usergroup.class, c, false,
-      reply -> {
-        if (reply.succeeded()) {
-          @SuppressWarnings("unchecked")
-          List<Usergroup> userGroup = reply.result().getResults();
-          if (userGroup.isEmpty()) {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetGroupsByGroupIdResponse
-              .respond404WithTextPlain(groupId)));
-          } else {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetGroupsByGroupIdResponse
-              .respond200WithApplicationJson(userGroup.get(0))));
-          }
-        } else {
-          log.error(reply.cause().getMessage(), reply.cause());
-          if (isInvalidUUID(reply.cause().getMessage())) {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetGroupsByGroupIdResponse
-              .respond404WithTextPlain(groupId)));
-          } else {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetGroupsByGroupIdResponse
-              .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
-          }
-        }
-      });
+    PgUtil.getById(GROUP_TABLE, Usergroup.class, groupId, okapiHeaders, vertxContext,
+        GetGroupsByGroupIdResponse.class, asyncResultHandler);
   }
 
   @Validate
@@ -126,46 +80,8 @@ public class UserGroupAPI implements Groups {
   public void deleteGroupsByGroupId(String groupId, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    Criterion criterion = new Criterion(
-      new Criteria()
-        .addField(ID_FIELD_NAME)
-        .setJSONB(false)
-        .setOperation("=")
-        .setVal(groupId));
-    PostgresClient postgresClient = PostgresClientUtil.getInstance(vertxContext, okapiHeaders);
-    postgresClient.get(GROUP_TABLE, Usergroup.class, criterion, true, getReply -> {
-      if (getReply.failed()) {
-        log.error(getReply.cause().getMessage(), getReply.cause());
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteGroupsByGroupIdResponse
-          .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
-      } else {
-        List<Usergroup> userGroup = getReply.result().getResults();
-        if (userGroup.isEmpty()) {
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteGroupsByGroupIdResponse
-            .respond404WithTextPlain(groupId)));
-          return;
-        }
-        User u = new User();
-        u.setPatronGroup(groupId);
-        postgresClient.get(UsersAPI.TABLE_NAME_USERS, u, true, false, replyHandler -> {
-          if (replyHandler.failed()) {
-            log.error(replyHandler.cause().getMessage(), replyHandler.cause());
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteGroupsByGroupIdResponse
-              .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
-            return;
-          }
-          List<User> userList = replyHandler.result().getResults();
-          if (userList.size() > 0) {
-            log.error("Can not delete group, " + groupId + ". " + userList.size() + " users associated with it");
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteGroupsByGroupIdResponse
-              .respond400WithTextPlain("Can not delete group, " + userList.size() + " users associated with it")));
-            return;
-          }
-          PgUtil.deleteById(GROUP_TABLE, groupId, okapiHeaders, vertxContext,
-            DeleteGroupsByGroupIdResponse.class, asyncResultHandler);
-        });
-      }
-    });
+    PgUtil.deleteById(GROUP_TABLE, groupId, okapiHeaders, vertxContext,
+        DeleteGroupsByGroupIdResponse.class, asyncResultHandler);
   }
 
   @Validate
@@ -174,32 +90,11 @@ public class UserGroupAPI implements Groups {
     Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
 
-    // PgUtil.put returns differnet status code , so can't be used here.
-    // probably 500 where it should have been 400/404
-    PostgresClientUtil.getInstance(vertxContext, okapiHeaders).update(
-      GROUP_TABLE, entity, groupId,
-      reply -> {
-        if (reply.succeeded()) {
-          if (reply.result().getUpdated() == 0) {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutGroupsByGroupIdResponse
-              .respond404WithTextPlain(messages.getMessage(lang, MessageConsts.NoRecordsUpdated))));
-          } else {
-            asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutGroupsByGroupIdResponse
-              .respond204()));
-          }
-        } else {
-          log.error(reply.cause().getMessage());
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutGroupsByGroupIdResponse
-            .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
-        }
-      });
+    PgUtil.put(GROUP_TABLE, entity, groupId, okapiHeaders, vertxContext,
+        PutGroupsByGroupIdResponse.class, asyncResultHandler);
   }
 
   private boolean isDuplicate(String errorMessage) {
     return errorMessage != null && errorMessage.contains("duplicate key value violates unique constraint");
-  }
-
-  private boolean isInvalidUUID(String errorMessage) {
-    return errorMessage != null && errorMessage.contains("uuid");
   }
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -2,9 +2,26 @@
   "scripts" : [],
   "tables" : [
     {
+      "tableName" : "groups",
+      "fromModuleVersion" : "14.3",
+      "withMetadata" : true,
+      "uniqueIndex" : [
+        {
+          "fieldName" : "group",
+          "tOps" : "ADD"
+        }
+      ]
+    },
+    {
       "tableName" : "users",
       "fromModuleVersion" : "14.3",
       "withMetadata" : true,
+      "foreignKeys": [
+        {
+          "fieldName": "patronGroup",
+          "targetTable": "groups"
+        }
+      ],
       "uniqueIndex" : [
         {
           "fieldName" : "username",
@@ -77,17 +94,6 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true
-        }
-      ]
-    },
-    {
-      "tableName" : "groups",
-      "fromModuleVersion" : "14.3",
-      "withMetadata" : true,
-      "uniqueIndex" : [
-        {
-          "fieldName" : "group",
-          "tOps" : "ADD"
         }
       ]
     },

--- a/src/test/java/org/folio/moduserstest/UserGroupAPITest.java
+++ b/src/test/java/org/folio/moduserstest/UserGroupAPITest.java
@@ -1,0 +1,35 @@
+package org.folio.moduserstest;
+
+import java.util.Collections;
+
+import org.folio.rest.impl.UserGroupAPI;
+import org.folio.rest.jaxrs.model.Usergroup;
+import org.folio.rest.tools.utils.VertxUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class UserGroupAPITest {
+  Vertx vertx = VertxUtils.getVertxWithExceptionHandler();
+  Context vertxContext = vertx.getOrCreateContext();
+
+  public class MyUserGroupAPI extends UserGroupAPI {
+    @Override
+    protected boolean isDuplicate(String errorMessage) {
+      throw new RuntimeException("testing exception handling");
+    }
+  }
+
+  @Test
+  public void postException(TestContext context) {
+    new MyUserGroupAPI().postGroups("en", new Usergroup(), Collections.emptyMap(), context.asyncAssertSuccess(result -> {
+      context.assertTrue(result.getEntity().toString().toLowerCase().contains("internal server error"));
+    }), vertxContext);
+  }
+
+}


### PR DESCRIPTION
* Use latest PgUtil.post, PgUtil.getById, PgUtil.deleteById, PgUtil.put where
  possible, RMB 26.1.0 has fixed some HTTP status codes.
* Use foreign key users.patronGroup=groups.id
* Extract duplicate unit test code into fail and assertStatus methods.
* Remove postgres-embedded code, this is automatically handled by PostgresClient.