### PR TITLE
MODUSERS-153 Calculate custom field usage on User records

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -118,7 +118,7 @@
     },
     {
       "id": "custom-fields",
-      "version": "1.0",
+      "version": "1.1",
       "interfaceType" : "multiple",
       "handlers": [
         {
@@ -145,6 +145,11 @@
           "methods": ["DELETE"],
           "pathPattern": "/custom-fields/{id}",
           "permissionsRequired": ["user-settings.custom-fields.item.delete"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/custom-fields/{id}/stats",
+          "permissionsRequired": ["user-settings.custom-fields.item.stats.get"]
         }
       ]
     },
@@ -325,6 +330,11 @@
       "description": "Delete User Custom Field"
     },
     {
+      "permissionName": "user-settings.custom-fields.item.stats.get",
+      "displayName": "User Custom Fields - get item usage statistic",
+      "description": "Get Custom Field Statistic"
+    },
+    {
       "permissionName": "user-settings.custom-fields.all",
       "displayName": "User Custom Fields module - all permissions",
       "description": "Entire set of permissions needed to use the user custom fields",
@@ -333,7 +343,8 @@
         "user-settings.custom-fields.item.post",
         "user-settings.custom-fields.item.get",
         "user-settings.custom-fields.item.put",
-        "user-settings.custom-fields.item.delete"
+        "user-settings.custom-fields.item.delete",
+        "user-settings.custom-fields.item.stats.get"
       ],
       "visible": false
     }

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-custom-fields</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <version>0.1.0</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,18 @@
       <type>jar</type>
     </dependency>
     <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>${rest-assured.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-service-tools-test</artifactId>
+      <version>${folio-service-tools.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>testing</artifactId>
       <version>${raml-module-builder.version}</version>
@@ -426,6 +438,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <raml-module-builder.version>27.0.0</raml-module-builder.version>
     <vertx.version>3.5.4</vertx.version>
+    <rest-assured.version>3.3.0</rest-assured.version>
+    <folio-service-tools.version>1.2.0</folio-service-tools.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
   </properties>
 </project>

--- a/src/main/java/org/folio/service/impl/RecordRepository.java
+++ b/src/main/java/org/folio/service/impl/RecordRepository.java
@@ -1,0 +1,12 @@
+package org.folio.service.impl;
+
+import io.vertx.core.Future;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomFieldStatistic;
+
+public interface RecordRepository {
+
+  Future<CustomFieldStatistic> retrieveStatisticForField(CustomField field, String tenantId);
+
+}

--- a/src/main/java/org/folio/service/impl/RecordRepositoryImpl.java
+++ b/src/main/java/org/folio/service/impl/RecordRepositoryImpl.java
@@ -1,0 +1,46 @@
+package org.folio.service.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.sql.ResultSet;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomFieldStatistic;
+import org.folio.rest.persist.PostgresClient;
+
+public class RecordRepositoryImpl implements RecordRepository {
+
+  private static final String USERS_TABLE = "users";
+  private static final String SELECT_USAGE_COUNT =
+    "SELECT count(*)" +
+    "  FROM " + USERS_TABLE +
+    "  WHERE jsonb -> 'customFields' ->> '%s' IS NOT NULL";
+
+  private Vertx vertx;
+
+
+  public RecordRepositoryImpl(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  public Future<CustomFieldStatistic> retrieveStatisticForField(CustomField field, String tenantId) {
+    Future<ResultSet> count = Future.future();
+
+    pgClient(tenantId).select(String.format(SELECT_USAGE_COUNT, field.getRefId()), count);
+
+    return count.map(rs -> statistic(field, rs.getResults().get(0).getInteger(0)));
+  }
+
+  private CustomFieldStatistic statistic(CustomField field, Integer count) {
+    return new CustomFieldStatistic()
+      .withFieldId(field.getId())
+      .withEntityType(field.getEntityType())
+      .withCount(count);
+  }
+
+  private PostgresClient pgClient(String tenantId) {
+    return PostgresClient.getInstance(vertx, tenantId);
+  }
+
+}

--- a/src/main/java/org/folio/service/impl/RecordServiceFactoryImpl.java
+++ b/src/main/java/org/folio/service/impl/RecordServiceFactoryImpl.java
@@ -1,0 +1,15 @@
+package org.folio.service.impl;
+
+import io.vertx.core.Vertx;
+
+import org.folio.service.RecordService;
+import org.folio.service.spi.RecordServiceFactory;
+
+public class RecordServiceFactoryImpl implements RecordServiceFactory {
+
+  @Override
+  public RecordService create(Vertx vertx) {
+    return new RecordServiceImpl(vertx);
+  }
+
+}

--- a/src/main/java/org/folio/service/impl/RecordServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RecordServiceImpl.java
@@ -1,0 +1,31 @@
+package org.folio.service.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomFieldStatistic;
+import org.folio.service.RecordService;
+
+public class RecordServiceImpl implements RecordService {
+
+  private RecordRepository repository;
+
+
+  public RecordServiceImpl(Vertx vertx) {
+    this.repository = new RecordRepositoryImpl(vertx);
+  }
+
+  @Override
+  public Future<CustomFieldStatistic> retrieveStatistic(CustomField field, String tenantId) {
+    return repository.retrieveStatisticForField(field, tenantId);
+  }
+
+  @Override
+  public Future<Void> deleteAllValues(CustomField field, String tenantId) {
+    return succeededFuture();
+  }
+
+}

--- a/src/main/resources/META-INF/services/org.folio.service.spi.RecordServiceFactory
+++ b/src/main/resources/META-INF/services/org.folio.service.spi.RecordServiceFactory
@@ -1,0 +1,1 @@
+org.folio.service.impl.RecordServiceFactoryImpl

--- a/src/test/java/org/folio/moduserstest/RestVerticleIT.java
+++ b/src/test/java/org/folio/moduserstest/RestVerticleIT.java
@@ -89,8 +89,24 @@ public class RestVerticleIT {
   private static final String fooGroupData = "{\"group\": \"librarianFOO\",\"desc\": \"yet another basic lib group\"}";
   private static final String barGroupData = "{\"group\": \"librarianBAR\",\"desc\": \"and yet another basic lib group\"}";
 
-  private static final String postCustomField = "{\"id\": \"524d3210-9ca2-4f91-87b4-d2227d595aaa\", \"name\": \"Department\", \"visible\": true, \"required\": true, \"helpText\": \"Provide a department\", \"entityType\": \"user\", \"type\": \"TEXTBOX_SHORT\", \"textField\": { \"maxSize\": 150 }}";
-  private static final String putCustomField = "{\"id\": \"524d3210-9ca2-4f91-87b4-d2227d595aaa\", \"name\": \"Department updated\", \"visible\": false, \"required\": true, \"helpText\": \"Provide a department\", \"entityType\": \"user\", \"type\": \"TEXTBOX_SHORT\", \"textField\": {   \"maxSize\": 250 }}";
+  private static final String postCustomField = "{\"id\": \"524d3210-9ca2-4f91-87b4-d2227d595aaa\", " +
+    "\"name\": \"Department\", " +
+    "\"visible\": true, " +
+    "\"required\": true, " +
+    "\"helpText\": \"Provide a department\", " +
+    "\"entityType\": \"user\", " +
+    "\"type\": \"TEXTBOX_SHORT\", " +
+    "\"order\": 1, " +
+    "\"textField\": { \"maxSize\": 150 }}";
+  private static final String putCustomField = "{\"id\": \"524d3210-9ca2-4f91-87b4-d2227d595aaa\", " +
+    "\"name\": \"Department updated\", " +
+    "\"visible\": false, " +
+    "\"required\": true, " +
+    "\"helpText\": \"Provide a department\", " +
+    "\"entityType\": \"user\", " +
+    "\"type\": \"TEXTBOX_SHORT\", " +
+    "\"order\": 1, " +
+    "\"textField\": {   \"maxSize\": 250 }}";
 
   private static final String joeBlockId = "ba6baf95-bf14-4020-b44c-0cad269fb5c9";
   private static final String bobCircleId = "54afd8b8-fb3b-4de8-9b7c-299904887f7d";

--- a/src/test/java/org/folio/moduserstest/RestVerticleIT.java
+++ b/src/test/java/org/folio/moduserstest/RestVerticleIT.java
@@ -11,12 +11,13 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
-import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
-import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
+import static org.folio.util.StringUtil.urlEncode;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
@@ -30,25 +31,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
-import org.folio.rest.RestVerticle;
-import org.folio.rest.client.TenantClient;
-import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.jaxrs.model.Parameter;
-import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.rest.tools.parser.JsonPathParser;
-import org.folio.rest.tools.utils.NetworkUtils;
-import org.folio.rest.tools.utils.VertxUtils;
-import org.folio.rest.utils.ExpirationTool;
-import org.folio.util.StringUtil;
-import org.joda.time.DateTime;
-import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
 
 import io.vertx.core.Context;
 import io.vertx.core.DeploymentOptions;
@@ -69,6 +51,27 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import junit.framework.AssertionFailedError;
+import org.joda.time.DateTime;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.parser.JsonPathParser;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.tools.utils.VertxUtils;
+import org.folio.rest.utils.ExpirationTool;
+import org.folio.util.StringUtil;
 
 @RunWith(VertxUnitRunner.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -204,6 +207,16 @@ public class RestVerticleIT {
           }
         });
     }));
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    vertx.close(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      future.complete(null);
+    });
+    future.join();
   }
 
   private Future<Void> getEmptyUsers(TestContext context) {

--- a/src/test/java/org/folio/moduserstest/UserGroupAPITest.java
+++ b/src/test/java/org/folio/moduserstest/UserGroupAPITest.java
@@ -1,28 +1,42 @@
 package org.folio.moduserstest;
 
 import java.util.Collections;
-
-import org.folio.rest.impl.UserGroupAPI;
-import org.folio.rest.jaxrs.model.Usergroup;
-import org.folio.rest.tools.utils.VertxUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.rest.impl.UserGroupAPI;
+import org.folio.rest.jaxrs.model.Usergroup;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.VertxUtils;
 
 @RunWith(VertxUnitRunner.class)
 public class UserGroupAPITest {
-  Vertx vertx = VertxUtils.getVertxWithExceptionHandler();
-  Context vertxContext = vertx.getOrCreateContext();
+  private static Vertx vertx = VertxUtils.getVertxWithExceptionHandler();
+  private static Context vertxContext = vertx.getOrCreateContext();
+
 
   public class MyUserGroupAPI extends UserGroupAPI {
     @Override
     protected boolean isDuplicate(String errorMessage) {
       throw new RuntimeException("testing exception handling");
     }
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    vertx.close(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      future.complete(null);
+    });
+    future.join();
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/CustomFieldStatisticsTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldStatisticsTest.java
@@ -1,21 +1,18 @@
 package org.folio.rest.impl;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import static org.folio.test.util.TestUtil.mockGetWithBody;
 import static org.folio.test.util.TestUtil.readFile;
 import static org.folio.test.util.TestUtil.toJson;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
-import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.restassured.http.Header;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
@@ -49,12 +46,7 @@ public class CustomFieldStatisticsTest extends TestBase {
 
     user8 = postWithStatus(USERS_PATH, user8Body, SC_CREATED, USER8).as(User.class);
 
-    stubFor(
-      get(new UrlPathPattern(new EqualToPattern("/" + USERS_PATH + "/" + user8.getId()), false))
-        .willReturn(new ResponseDefinitionBuilder()
-          .withStatus(200)
-          .withBody(user8Body)
-        ));
+    mockGetWithBody(new EqualToPattern("/" + USERS_PATH + "/" + user8.getId()), user8Body);
 
     textField = postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/shortTextField.json"), SC_CREATED, USER8)
       .as(CustomField.class);

--- a/src/test/java/org/folio/rest/impl/CustomFieldStatisticsTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldStatisticsTest.java
@@ -1,0 +1,98 @@
+package org.folio.rest.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import static org.folio.test.util.TestUtil.readFile;
+import static org.folio.test.util.TestUtil.toJson;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import io.restassured.http.Header;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomFieldStatistic;
+import org.folio.rest.jaxrs.model.CustomFields;
+import org.folio.rest.jaxrs.model.User;
+import org.folio.test.util.TestBase;
+
+@RunWith(VertxUnitRunner.class)
+public class CustomFieldStatisticsTest extends TestBase {
+
+  private static final String STUB_FIELD_ID = "11111111-1111-1111-a111-111111111111";
+
+  private static final Header USER8 = new Header(XOkapiHeaders.USER_ID, "88888888-8888-4888-8888-888888888888");
+
+  private static final String USERS_PATH = "users";
+  private static final String CUSTOM_FIELDS_PATH = "custom-fields";
+
+  private User user8;
+  private CustomField textField;
+
+  @Before
+  public void setUp() throws IOException, URISyntaxException {
+    String user8Body = readFile("users/user8.json");
+
+    user8 = postWithStatus(USERS_PATH, user8Body, SC_CREATED, USER8).as(User.class);
+
+    stubFor(
+      get(new UrlPathPattern(new EqualToPattern("/" + USERS_PATH + "/" + user8.getId()), false))
+        .willReturn(new ResponseDefinitionBuilder()
+          .withStatus(200)
+          .withBody(user8Body)
+        ));
+
+    textField = postWithStatus(CUSTOM_FIELDS_PATH, readFile("fields/shortTextField.json"), SC_CREATED, USER8)
+      .as(CustomField.class);
+  }
+
+  @After
+  public void tearDown() {
+    CustomFieldsDBTestUtil.deleteAllCustomFields(vertx);
+
+    deleteWithNoContent(USERS_PATH + "/" + user8.getId());
+  }
+
+  @Test
+  public void shouldReturnZeroUsageIfNoFieldsAssigned() {
+    CustomFieldStatistic stat = getWithOk(CUSTOM_FIELDS_PATH + "/" + textField.getId() + "/stats")
+        .as(CustomFieldStatistic.class);
+
+    assertThat(stat.getFieldId(), equalTo(textField.getId()));
+    assertThat(stat.getEntityType(), equalTo(textField.getEntityType()));
+    assertThat(stat.getCount(), equalTo(0));
+  }
+
+  @Test
+  public void shouldReturnUsageCountIfFieldAssigned() {
+    user8.withCustomFields(new CustomFields().withAdditionalProperty(textField.getRefId(), "someValue"));
+    putWithNoContent(USERS_PATH + "/" + user8.getId(), toJson(user8), USER8);
+
+    CustomFieldStatistic stat = getWithOk(CUSTOM_FIELDS_PATH + "/" + textField.getId() + "/stats")
+      .as(CustomFieldStatistic.class);
+
+    assertThat(stat.getFieldId(), equalTo(textField.getId()));
+    assertThat(stat.getEntityType(), equalTo(textField.getEntityType()));
+    assertThat(stat.getCount(), equalTo(1));
+  }
+
+  @Test
+  public void shouldFailIfFieldNotExist() {
+    getWithStatus(CUSTOM_FIELDS_PATH + "/" + STUB_FIELD_ID + "/stats", SC_NOT_FOUND);
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/CustomFieldsDBTestUtil.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldsDBTestUtil.java
@@ -1,0 +1,32 @@
+package org.folio.rest.impl;
+
+import static org.folio.test.util.DBTestUtil.deleteFromTable;
+import static org.folio.test.util.DBTestUtil.getAll;
+import static org.folio.test.util.DBTestUtil.save;
+import static org.folio.test.util.TestUtil.STUB_TENANT;
+
+import java.util.List;
+
+import io.vertx.core.Vertx;
+
+import org.folio.rest.jaxrs.model.CustomField;
+
+public class CustomFieldsDBTestUtil {
+
+  public static final String CUSTOM_FIELDS_TABLE = "custom_fields";
+
+  private CustomFieldsDBTestUtil() {
+  }
+
+  public static void deleteAllCustomFields(Vertx vertx) {
+    deleteFromTable(vertx, CUSTOM_FIELDS_TABLE, STUB_TENANT);
+  }
+
+  public static List<CustomField> getAllCustomFields(Vertx vertx) {
+    return getAll(CustomField.class, vertx, CUSTOM_FIELDS_TABLE, STUB_TENANT);
+  }
+
+  public static void saveCustomField(String id, CustomField customField, Vertx vertx) {
+    save(id, customField, vertx, CUSTOM_FIELDS_TABLE, STUB_TENANT);
+  }
+}

--- a/src/test/resources/fields/shortTextField.json
+++ b/src/test/resources/fields/shortTextField.json
@@ -1,0 +1,13 @@
+{
+  "name": "Department",
+  "type" : "TEXTBOX_SHORT",
+  "refId": "not-null-ref-id",
+  "visible": true,
+  "required": true,
+  "entityType": "user",
+  "helpText": "Provide a department",
+  "order": 1,
+  "textField": {
+    "maxSize": 100
+  }
+}

--- a/src/test/resources/users/user8.json
+++ b/src/test/resources/users/user8.json
@@ -1,0 +1,16 @@
+{
+  "username": "mockuser8",
+  "id": "88888888-8888-4888-8888-888888888888",
+  "active": true,
+  "type": "patron",
+  "meta": {
+    "creation_date": "2016-11-05T0723",
+    "last_login_date": ""
+  },
+  "personal": {
+    "firstName": "Haslett",
+    "lastName": "Lintall",
+    "email": "hlintall1@si.edu",
+    "phone": "927-306-2327"
+  }
+}


### PR DESCRIPTION
## Purpose
Per [MODUSERS-153](https://issues.folio.org/browse/MODUSERS-153), calculate custom field usage on User records

## Approach
- define endpoint to retrieve CF usage statistic: `/custom-fields/{id}/stats`
- introduce `RecordRepository` to implement statistic calculation and CF values removal
- call `RecordRepository` from the implementation of RecordService 
- test the statistic endpoint
- modify existing tests to shutdown vert.x and posgtres in class tear down method 
- update mod-custom-fields dependency to a released version to solve the issue with continues snapshot version updates
