### PR TITLE
MODCFIELDS-30: Update fromModuleVersion for custom fields script

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -3,7 +3,7 @@
     {
       "run": "after",
       "snippetPath": "create_custom_fields_table.sql",
-      "fromModuleVersion": "1.0"
+      "fromModuleVersion": "mod-users-15.7.0"
     }
   ],
   "tables" : [


### PR DESCRIPTION
According to https://github.com/folio-org/raml-module-builder/blob/master/DB-schema-migration.md, 
we need to set custom field "fromModuleVersion" to "mod-users-15.7.0" (the version in which custom fields script was added)