### PR TITLE
MODUSERS-114 GET users as a stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-custom-fields</artifactId>
-      <version>0.1.0</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
@@ -436,10 +436,11 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <raml-module-builder.version>27.0.0</raml-module-builder.version>
-    <vertx.version>3.5.4</vertx.version>
+    <raml-module-builder.version>29.2.0-SNAPSHOT</raml-module-builder.version>
+    <generate_routing_context>/users</generate_routing_context>
+    <vertx.version>3.8.4</vertx.version>
     <rest-assured.version>3.3.0</rest-assured.version>
-    <folio-service-tools.version>1.2.0</folio-service-tools.version>
+    <folio-service-tools.version>1.3.1</folio-service-tools.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <raml-module-builder.version>29.2.0-SNAPSHOT</raml-module-builder.version>
+    <raml-module-builder.version>29.2.0</raml-module-builder.version>
     <generate_routing_context>/users</generate_routing_context>
     <vertx.version>3.8.4</vertx.version>
     <rest-assured.version>3.3.0</rest-assured.version>

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -52,6 +52,7 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -538,7 +539,7 @@ public class UsersAPI implements Users {
   private Future<Boolean> checkAddressTypeValid(
       String addressTypeId, Context vertxContext, PostgresClient postgresClient) {
 
-    Future<Boolean> future = Future.future();
+    Promise<Boolean> future = Promise.promise();
     Criterion criterion = new Criterion(
           new Criteria().addField(AddressTypeAPI.ID_FIELD_NAME).
                   setJSONB(false).setOperation("=").setVal(addressTypeId));
@@ -570,15 +571,15 @@ public class UsersAPI implements Users {
         future.fail(e);
       }
     });
-    return future;
+    return future.future();
   }
 
   private Future<Boolean> checkAllAddressTypesValid(User user, Context vertxContext, PostgresClient postgresClient) {
-    Future<Boolean> future = Future.future();
+    Promise<Boolean> future = Promise.promise();
     List<Future> futureList = new ArrayList<>();
     if (user.getPersonal() == null || user.getPersonal().getAddresses() == null) {
       future.complete(true);
-      return future;
+      return future.future();
     }
     for (Address address : user.getPersonal().getAddresses()) {
       String addressTypeId = address.getAddressTypeId();
@@ -603,7 +604,7 @@ public class UsersAPI implements Users {
         }
       }
     });
-    return future;
+    return future.future();
   }
 
   private Map<String, Object> getCustomFields(User entity) {

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -22,6 +22,7 @@ import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Address;
 import org.folio.rest.jaxrs.model.AddressType;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.jaxrs.model.UserdataCollection;
 import org.folio.rest.jaxrs.model.UsersGetOrder;
@@ -43,13 +44,18 @@ import org.folio.validate.CustomFieldValidationException;
 import org.folio.validate.ValidationServiceImpl;
 import org.z3950.zing.cql.CQLParseException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.RoutingContext;
 
 
 /**
@@ -66,6 +72,19 @@ public class UsersAPI implements Users {
   public static final String USER_ID_FIELD = "'id'";
   public static final String USER_NAME_FIELD = "'username'";
   private final Logger logger = LoggerFactory.getLogger(UsersAPI.class);
+
+  public static final int STREAM_THRESHOLD = 200;
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  private static final String JSON_USERS_HEADER = "{\n" +
+      "  \"users\": [";
+  private static final String JSON_USERS_FOOTER = "],\n" +
+      "  \"totalRecords\": %d,\n" +
+      "  \"resultInfo\": {\n" +
+      "    \"totalRecords\": %d,\n" +
+      "    \"facets\": [],\n" +
+      "    \"diagnostics\": []\n" +
+      "  }\n" +
+      "}";
 
   /**
    * right now, just query the join view if a cql was passed in, otherwise work with the
@@ -136,7 +155,7 @@ public class UsersAPI implements Users {
   @Override
   public void getUsers(String query, String orderBy,
       UsersGetOrder order, int offset, int limit, List<String> facets,
-      String lang, Map <String, String> okapiHeaders,
+      String lang, RoutingContext routingContext, Map <String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
 
@@ -149,6 +168,33 @@ public class UsersAPI implements Users {
       String tableName = getTableName(query);
       String[] fieldList = {"*"};
       logger.debug("Headers present are: " + okapiHeaders.keySet().toString());
+
+      if (limit >= STREAM_THRESHOLD) {
+        logger.debug("Getting users as a stream ...");
+        HttpServerResponse response = routingContext.response().putHeader("content-type", "application/json")
+            .setChunked(true).write(JSON_USERS_HEADER);
+        final int[] cnt = { 0 };
+        PgUtil.postgresClient(vertxContext, okapiHeaders).streamGet(tableName, new User(), "*", cql, true, null,
+            user -> {
+              if (cnt[0]++ > 0) {
+                response.write(",");
+              }
+              try {
+                response.write(JSON_MAPPER.writeValueAsString(user), "UTF-8");
+              } catch (JsonProcessingException e) {
+                logger.error("This error should never happen: " + e);
+              }
+            }, reply -> {
+              if (reply.succeeded()) {
+                response.write(String.format(JSON_USERS_FOOTER, cnt[0], cnt[0]));
+              } else {
+                response.setStatusCode(500).setStatusMessage(reply.cause().getLocalizedMessage());
+              }
+              response.end();
+              response.close();
+            });
+        return;
+      }
 
       PgUtil.postgresClient(vertxContext, okapiHeaders)
           .get(tableName, User.class, fieldList, cql, true, false, facetList, reply -> {
@@ -182,6 +228,7 @@ public class UsersAPI implements Users {
   @Validate
   @Override
   public void postUsers(String lang, User entity,
+                        RoutingContext routingContext,
                         Map<String, String> okapiHeaders,
                         Handler<AsyncResult<Response>> asyncResultHandler,
                         Context vertxContext) {
@@ -266,21 +313,28 @@ public class UsersAPI implements Users {
   }
 
   private boolean isDuplicateIdError(AsyncResult<Response> reply) {
-    return reply.succeeded()
-    && reply.result().getStatus() == 400
-    && reply.result().getEntity().toString().contains("users_pkey");
+    return isDesiredError(reply, ".*id.*already exists.*");
   }
 
   private boolean isDuplicateUsernameError(AsyncResult<Response> reply) {
-    return reply.succeeded()
-    && reply.result().getStatus() == 400
-    && reply.result().getEntity().toString().contains("users_username_idx_unique");
+    return isDesiredError(reply, ".*username.*already exists.*");
   }
 
   private boolean isDuplicateBarcodeError(AsyncResult<Response> reply) {
-    return reply.succeeded()
-    && reply.result().getStatus() == 400
-    && reply.result().getEntity().toString().contains("users_barcode_idx_unique");
+    return isDesiredError(reply, ".*barcode.*already exists.*");
+  }
+
+  private boolean isDesiredError(AsyncResult<Response> reply, String errMsg) {
+    if (reply.succeeded()) {
+      if (reply.result().getStatus() == 400) {
+        return reply.result().getEntity().toString().matches(errMsg);
+      }
+      if (reply.result().getStatus() == 422) {
+        String msg = ((Errors)reply.result().getEntity()).getErrors().iterator().next().getMessage();
+        return msg.matches(errMsg);
+      }
+    }
+    return false;
   }
 
   @Validate


### PR DESCRIPTION
This change expands existing `/users` API to switch to streaming mode automatically when the `limit` parameter is large (200 or above for example). This implementation simplified original POC where new RAML resource type, RAML, API and permissions were proposed. Note, this PR also includes some changes to handle RMB upgrade from v27 to v29. It also uses `RMB 29.2.0-SNAPSHOT` for now since `29.2.0` has not been released.