### PR TITLE
MODUSERS-114: Log exception including stacktrace for streaming GET Users

### DIFF
--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -190,7 +190,6 @@ public class UsersAPI implements Users {
               if (reply.succeeded()) {
                 response.write(String.format(JSON_USERS_FOOTER, cnt[0], cnt[0]));
               } else {
-                logger.error("Get users as a stream failed: " + reply.cause().getMessage(), reply.cause());
                 response.setStatusCode(500).setStatusMessage(reply.cause().getMessage());
               }
               response.end();

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -2,6 +2,7 @@ package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
 
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -183,13 +184,14 @@ public class UsersAPI implements Users {
               try {
                 response.write(JSON_MAPPER.writeValueAsString(user), "UTF-8");
               } catch (JsonProcessingException e) {
-                logger.error("This error should never happen: " + e);
+                throw new UncheckedIOException(e);
               }
             }, reply -> {
               if (reply.succeeded()) {
                 response.write(String.format(JSON_USERS_FOOTER, cnt[0], cnt[0]));
               } else {
-                response.setStatusCode(500).setStatusMessage(reply.cause().getLocalizedMessage());
+                logger.error("Get users as a stream failed: " + reply.cause().getMessage(), reply.cause());
+                response.setStatusCode(500).setStatusMessage(reply.cause().getMessage());
               }
               response.end();
               response.close();


### PR DESCRIPTION
Pass JsonProcessingException to reply handler to return a failure.

Do not swallow the exception stacktrace, log it.

Use English or the tenant language or the language requested by the client, but
not the language of the server.