### PR TITLE
RMB 29.2.2: Upgrade indexes on module upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <raml-module-builder.version>29.2.0</raml-module-builder.version>
+    <raml-module-builder.version>29.2.2</raml-module-builder.version>
     <generate_routing_context>/users</generate_routing_context>
     <vertx.version>3.8.4</vertx.version>
     <rest-assured.version>3.3.0</rest-assured.version>


### PR DESCRIPTION
Indexes do not get recreated on module upgrade resulting in bad performance.

Update RAML Module Builder (RMB) from 29.2.0 to 29.2.2 to get this fix:

[RMB-550](https://issues.folio.org/browse/RMB-550) Index recreation on module upgrade.

All indexes will be recreated on module upgrade, this may take long. This is needed for
[RMB-498](https://issues.folio.org/browse/RMB-498) and other index changes of 29.2.0.