### PR TITLE
MODUSERS-164  Upgrade to RMB v29.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-custom-fields</artifactId>
-      <version>0.1.0</version>
+      <version>1.0.2</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
@@ -445,7 +445,7 @@
     <raml-module-builder.version>29.1.1</raml-module-builder.version>
     <vertx.version>3.8.4</vertx.version>
     <rest-assured.version>3.3.0</rest-assured.version>
-    <folio-service-tools.version>1.2.0</folio-service-tools.version>
+    <folio-service-tools.version>1.3.0</folio-service-tools.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,14 +67,20 @@
       <artifactId>junit-vintage-engine</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
-     </dependency>
-     <dependency>
+    </dependency>
+    <dependency>
        <groupId>io.vertx</groupId>
        <artifactId>vertx-unit</artifactId>
        <version>${vertx.version}</version>
        <scope>test</scope>
        <type>jar</type>
-     </dependency>
+    </dependency>
+    <dependency>
+       <groupId>io.vertx</groupId>
+       <artifactId>vertx-junit5</artifactId>
+       <version>${vertx.version}</version>
+       <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
       <version>${raml-module-builder.version}</version>
@@ -53,13 +47,34 @@
       <artifactId>vertx-web</artifactId>
       <version>${vertx.version}</version>
     </dependency>
+
+    <!-- test dependencies -->
+
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <version>${vertx.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
-      <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+     </dependency>
+     <dependency>
+       <groupId>io.vertx</groupId>
+       <artifactId>vertx-unit</artifactId>
+       <version>${vertx.version}</version>
+       <scope>test</scope>
+       <type>jar</type>
+     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
@@ -76,6 +91,12 @@
       <groupId>org.folio</groupId>
       <artifactId>testing</artifactId>
       <version>${raml-module-builder.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.2.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -445,6 +466,7 @@
     <raml-module-builder.version>29.2.2</raml-module-builder.version>
     <generate_routing_context>/users</generate_routing_context>
     <vertx.version>3.8.4</vertx.version>
+    <junit.version>5.5.2</junit.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <folio-service-tools.version>1.3.1</folio-service-tools.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>mod-custom-fields</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
@@ -445,7 +445,7 @@
     <raml-module-builder.version>29.1.1</raml-module-builder.version>
     <vertx.version>3.8.4</vertx.version>
     <rest-assured.version>3.3.0</rest-assured.version>
-    <folio-service-tools.version>1.3.0</folio-service-tools.version>
+    <folio-service-tools.version>1.3.1</folio-service-tools.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
       <version>${raml-module-builder.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>${vertx.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -436,8 +442,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <raml-module-builder.version>27.0.0</raml-module-builder.version>
-    <vertx.version>3.5.4</vertx.version>
+    <raml-module-builder.version>29.1.1</raml-module-builder.version>
+    <vertx.version>3.8.4</vertx.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <folio-service-tools.version>1.2.0</folio-service-tools.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>

--- a/src/main/java/org/folio/rest/impl/ProxiesForAPI.java
+++ b/src/main/java/org/folio/rest/impl/ProxiesForAPI.java
@@ -118,7 +118,7 @@ public class ProxiesForAPI implements Proxiesfor {
     PgUtil.put(PROXY_FOR_TABLE, entity, id, okapiHeaders, vertxContext, PutProxiesforByIdResponse.class, asyncResultHandler);
   }
 
-  private Future<Boolean> userAndProxyUserComboExists(
+  Future<Boolean> userAndProxyUserComboExists(
     String userId,
     String proxyUserId,
     PostgresClient postgresClient) {

--- a/src/main/java/org/folio/rest/impl/ProxiesForAPI.java
+++ b/src/main/java/org/folio/rest/impl/ProxiesForAPI.java
@@ -1,10 +1,5 @@
 package org.folio.rest.impl;
 
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.core.Response;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -13,14 +8,17 @@ import io.vertx.core.Promise;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.Response;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.ProxiesFor;
 import org.folio.rest.jaxrs.model.ProxyforCollection;
 import org.folio.rest.jaxrs.resource.Proxiesfor;
-import org.folio.rest.persist.PgUtil;
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.ValidationHelper;
 
 /**

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -490,7 +490,7 @@ public class UsersAPI implements Users {
     entity.setUsername(username);
   }
 
-  private Future<Boolean> checkAddressTypeValid(
+  Future<Boolean> checkAddressTypeValid(
       String addressTypeId, Context vertxContext, PostgresClient postgresClient) {
 
     Promise<Boolean> promise = Promise.promise();
@@ -524,7 +524,7 @@ public class UsersAPI implements Users {
     return promise.future();
   }
 
-  private Future<Boolean> checkAllAddressTypesValid(User user, Context vertxContext, PostgresClient postgresClient) {
+  Future<Boolean> checkAllAddressTypesValid(User user, Context vertxContext, PostgresClient postgresClient) {
     Promise<Boolean> promise = Promise.promise();
     List<Future> futureList = new ArrayList<>();
     if (user.getPersonal() == null || user.getPersonal().getAddresses() == null) {
@@ -540,19 +540,15 @@ public class UsersAPI implements Users {
     compositeFuture.setHandler(res -> {
       if (res.failed()) {
         promise.fail(res.cause());
-      } else {
-        boolean bad = false;
-        for (Future<Boolean> f : futureList) {
-          if (Boolean.FALSE.equals(f.result())) {
-            promise.complete(false);
-            bad = true;
-            break;
-          }
-        }
-        if (!bad) {
-          promise.complete(true);
+        return;
+      }
+      for (Future<Boolean> f : futureList) {
+        if (Boolean.FALSE.equals(f.result())) {
+          promise.complete(false);
+          return;
         }
       }
+      promise.complete(true);
     });
     return promise.future();
   }

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -70,8 +70,6 @@ public class UsersAPI implements Users {
   public static final String VIEW_NAME_USER_GROUPS_JOIN = "users_groups_view";
 
   private final Messages messages = Messages.getInstance();
-  public static final String USER_ID_FIELD = "'id'";
-  public static final String USER_NAME_FIELD = "'username'";
   private final Logger logger = LoggerFactory.getLogger(UsersAPI.class);
 
   public static final int STREAM_THRESHOLD = 200;

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -15,22 +15,8 @@ import java.util.function.Function;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-import io.vertx.ext.web.RoutingContext;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
-import org.z3950.zing.cql.CQLParseException;
-
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.CQL2PgJSONException;
 import org.folio.cql2pgjson.exception.FieldException;
@@ -42,12 +28,12 @@ import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.jaxrs.model.UserdataCollection;
 import org.folio.rest.jaxrs.model.UsersGetOrder;
 import org.folio.rest.jaxrs.resource.Users;
-import org.folio.rest.persist.PgUtil;
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.persist.facets.FacetField;
 import org.folio.rest.persist.facets.FacetManager;
@@ -57,6 +43,21 @@ import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
 import org.folio.validate.CustomFieldValidationException;
 import org.folio.validate.ValidationServiceImpl;
+import org.z3950.zing.cql.CQLParseException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.RoutingContext;
 
 
 /**
@@ -153,10 +154,10 @@ public class UsersAPI implements Users {
   @Validate
   @Override
   public void getUsers(String query, String orderBy,
-       UsersGetOrder order, int offset, int limit, List<String> facets,
-       String lang, RoutingContext routingContext, Map <String, String> okapiHeaders,
-       Handler<AsyncResult<Response>> asyncResultHandler,
-       Context vertxContext) {
+      UsersGetOrder order, int offset, int limit, List<String> facets,
+      String lang, RoutingContext routingContext, Map <String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
 
     logger.debug("Getting users");
     try {

--- a/src/main/java/org/folio/rest/utils/ExpirationTool.java
+++ b/src/main/java/org/folio/rest/utils/ExpirationTool.java
@@ -14,25 +14,24 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.function.BiFunction;
+
 import static org.folio.rest.impl.UsersAPI.TABLE_NAME_USERS;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
 
-/**
- *
- * @author kurt
- */
-public class ExpirationTool {
+public final class ExpirationTool {
+  private static final Logger logger = LoggerFactory.getLogger(ExpirationTool.class);
+  /** PostgresClient::getInstance, or some other method for unit testing */
+  static BiFunction<Vertx, String, PostgresClient> postgresClient = PostgresClient::getInstance;
 
   private ExpirationTool() {
-    //do nothing
+    throw new UnsupportedOperationException("Cannot instantiate utility class.");
   }
 
-
   public static void doExpiration(Vertx vertx, Context context) {
-    final Logger logger = LoggerFactory.getLogger(ExpirationTool.class);
     logger.info("Calling doExpiration()");
     context.runOnContext(v -> {
       //Get a list of tenants
@@ -66,74 +65,68 @@ public class ExpirationTool {
   }
 
   public static Future<Integer> doExpirationForTenant(Vertx vertx, Context context, String tenant) {
-    final Logger logger = LoggerFactory.getLogger(ExpirationTool.class);
     Promise<Integer> promise = Promise.promise();
-    String nowDateString =  new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS\'Z\'").format(new Date());
-
-    context.runOnContext(v -> {
-      PostgresClient pgClient = PostgresClient.getInstance(vertx, tenant);
+    try {
+      String nowDateString =  new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS\'Z\'").format(new Date());
       String query = String.format("active == true AND expirationDate < %s", nowDateString);
-      CQL2PgJSON cql2pgJson;
-      CQLWrapper cqlWrapper;
+      CQL2PgJSON cql2pgJson = new CQL2PgJSON(Arrays.asList(TABLE_NAME_USERS+".jsonb"));
+      CQLWrapper cqlWrapper = new CQLWrapper(cql2pgJson, query);
       String[] fieldList = {"*"};
-      try {
-        cql2pgJson = new CQL2PgJSON(Arrays.asList(TABLE_NAME_USERS+".jsonb"));
-        cqlWrapper = new CQLWrapper(cql2pgJson, query);
-      } catch(Exception e) {
-        promise.fail(e.getLocalizedMessage());
-        return;
-      }
+      PostgresClient pgClient = postgresClient.apply(vertx, tenant);
       pgClient.get(TABLE_NAME_USERS, User.class, fieldList, cqlWrapper, true, false, reply -> {
-        if(reply.failed()) {
+        if (reply.failed()) {
           logger.info(String.format("Error executing postgres query: '%s', %s",
             query, reply.cause().getLocalizedMessage()));
           promise.fail(reply.cause());
-        } else if(reply.result().getResults().isEmpty()) {
-          logger.info(String.format("No results found for query %s", query));
-        } else {
-          List<User> userList = reply.result().getResults();
-          List<Future> futureList = new ArrayList<>();
-          for(User user : userList) {
-            user.setActive(Boolean.FALSE);
-            Future<Void> saveFuture = saveUser(vertx, context, tenant, user);
-            futureList.add(saveFuture);
-          }
-          CompositeFuture compositeFuture = CompositeFuture.join(futureList);
-          compositeFuture.setHandler(compRes -> {
-            int succeededCount = 0;
-            for(Future fut : futureList) {
-              if(fut.succeeded()) {
-                succeededCount++;
-              }
-            }
-            promise.complete(succeededCount);
-          });
+          return;
         }
+        if (reply.result().getResults().isEmpty()) {
+          logger.info(String.format("No results found for query %s", query));
+          promise.complete(0);
+          return;
+        }
+        List<User> userList = reply.result().getResults();
+        List<Future> futureList = new ArrayList<>();
+        for(User user : userList) {
+          user.setActive(Boolean.FALSE);
+          Future<Void> saveFuture = saveUser(vertx, tenant, user);
+          futureList.add(saveFuture);
+        }
+        CompositeFuture compositeFuture = CompositeFuture.join(futureList);
+        compositeFuture.setHandler(compRes -> {
+          int succeededCount = 0;
+          for(Future fut : futureList) {
+            if(fut.succeeded()) {
+              succeededCount++;
+            }
+          }
+          promise.complete(succeededCount);
+        });
       });
-    });
+    } catch (Exception e) {
+      logger.error(e.getMessage(), e);
+      promise.fail(e);
+    }
     return promise.future();
   }
 
-  private static Future<Void> saveUser(Vertx vertx, Context context, String tenant, User user) {
-    final Logger logger = LoggerFactory.getLogger(ExpirationTool.class);
+  static Future<Void> saveUser(Vertx vertx, String tenant, User user) {
     logger.info(String.format("Updating user with id %s", user.getId()));
     Promise<Void> promise = Promise.promise();
-    context.runOnContext(v -> {
-      try {
-        PostgresClient pgClient = PostgresClient.getInstance(vertx, tenant);
-        pgClient.update(TABLE_NAME_USERS, user, user.getId(), updateReply -> {
-          if(updateReply.failed()) {
-            logger.info(String.format("Error updating user %s: %s", user.getId(),
-              updateReply.cause().getLocalizedMessage()));
-            promise.fail(updateReply.cause());
-          } else {
-            promise.complete();
-          }
-        });
-      } catch(Exception e) {
-        promise.tryFail(e);
-      }
-    });
+    try {
+      PostgresClient pgClient = postgresClient.apply(vertx, tenant);
+      pgClient.update(TABLE_NAME_USERS, user, user.getId(), updateReply -> {
+        if (updateReply.succeeded()) {
+          promise.complete();
+          return;
+        }
+        logger.info(String.format("Error updating user %s: %s", user.getId(),
+          updateReply.cause().getLocalizedMessage()));
+        promise.fail(updateReply.cause());
+      });
+    } catch(Exception e) {
+      promise.tryFail(e);
+    }
     return promise.future();
   }
 

--- a/src/main/java/org/folio/rest/utils/ExpirationTool.java
+++ b/src/main/java/org/folio/rest/utils/ExpirationTool.java
@@ -1,14 +1,6 @@
 package org.folio.rest.utils;
 
 
-import static org.folio.rest.impl.UsersAPI.TABLE_NAME_USERS;
-
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -17,7 +9,12 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import static org.folio.rest.impl.UsersAPI.TABLE_NAME_USERS;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.persist.PostgresClient;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -48,6 +48,10 @@
           "tOps" : "ADD"
         },
         {
+          "fieldName" : "username",
+          "tOps" : "DELETE"
+        },
+        {
           "fieldName" : "personal.firstName",
           "tOps" : "ADD"
         },

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -20,7 +20,7 @@
     },
     {
       "tableName" : "users",
-      "fromModuleVersion" : "14.3",
+      "fromModuleVersion" : "mod-users-16.0.1",
       "withMetadata" : true,
       "foreignKeys": [
         {
@@ -32,6 +32,10 @@
         {
           "fieldName" : "username",
           "tOps" : "ADD"
+        },
+        {
+          "fieldName" : "id",
+          "tOps" : "DELETE"
         },
         {
           "fieldName" : "barcode",
@@ -59,6 +63,12 @@
         }
       ],
       "ginIndex": [
+        {
+          "fieldName": "id",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
         {
           "fieldName": "username",
           "tOps": "ADD",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -34,10 +34,6 @@
           "tOps" : "ADD"
         },
         {
-          "fieldName" : "id",
-          "tOps" : "ADD"
-        },
-        {
           "fieldName" : "barcode",
           "tOps" : "ADD"
         }
@@ -45,10 +41,6 @@
       "index" : [
         {
           "fieldName" : "externalSystemId",
-          "tOps" : "ADD"
-        },
-        {
-          "fieldName" : "username",
           "tOps" : "ADD"
         },
         {
@@ -67,12 +59,6 @@
         }
       ],
       "ginIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
-        },
         {
           "fieldName": "username",
           "tOps": "ADD",

--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -1,11 +1,15 @@
 package org.folio.moduserstest;
 
+import static io.vertx.core.json.Json.encode;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import static org.folio.moduserstest.RestITSupport.deleteWithNoContentStatus;
 import static org.folio.moduserstest.RestITSupport.getJson;
+import static org.folio.moduserstest.RestITSupport.post;
 import static org.folio.moduserstest.RestITSupport.postWithOkStatus;
+import static org.folio.moduserstest.RestITSupport.put;
 import static org.folio.moduserstest.RestITSupport.putWithNoContentStatus;
 import static org.folio.util.StringUtil.urlEncode;
 
@@ -13,9 +17,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -23,25 +31,32 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.client.HttpResponse;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 
 @RunWith(VertxUnitRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class CustomFieldIT {
 
   private static final Logger log = LoggerFactory.getLogger(CustomFieldIT.class);
 
   private static final String joeBlockId = "ba6baf95-bf14-4020-b44c-0cad269fb5c9";
+  private static final String johnRectangleId = "ae6d1c57-3041-4645-9215-3ca0094b77fc";
+  private static final String notExistingCustomField = "notExistingCustomField";
 
   private static final String customFieldsPath = "/custom-fields";
 
@@ -121,21 +136,42 @@ public class CustomFieldIT {
   }
 
   @Test
+  public void test1Sequential(TestContext context) {
+    Async async = context.async();
+
+    postUser()
+      .compose(v -> postCustomField())
+      .compose(v -> postUserWithCustomFields())
+      .compose(v -> getUserWithCustomFields(context))
+      .compose(v -> deleteUser(context, johnRectangleId))
+      .compose(v -> putUserWithNotExistingCustomField(context))
+      .compose(v -> postUserWithNotExistingCustomField(context))
+      .compose(v -> deleteUser(context, joeBlockId))
+      .compose(v -> deleteCustomField(context))
+      .setHandler(testResultHandler(context, async));
+  }
+
+  @Test
   public void test4CustomFields(TestContext context) {
     Async async = context.async();
     postUser()
       .compose(v -> postCustomField())
       .compose(v -> putCustomField(context))
       .compose(v -> queryCustomField(context)).compose(this::assertCustomFieldValues)
+      .compose(v -> deleteUser(context, joeBlockId))
       .compose(v -> deleteCustomField(context))
-      .setHandler(res -> {
-        if (res.succeeded()) {
-          async.complete();
-        } else {
-          res.cause().printStackTrace();
-          context.fail(res.cause());
-        }
-      });
+      .setHandler(testResultHandler(context, async));
+  }
+
+  private Handler<AsyncResult<Void>> testResultHandler(TestContext context, Async async) {
+    return res -> {
+      if (res.succeeded()) {
+        async.complete();
+      } else {
+        res.cause().printStackTrace();
+        context.fail(res.cause());
+      }
+    };
   }
 
   private Future<Void> postUser() {
@@ -147,6 +183,101 @@ public class CustomFieldIT {
       .put("username", "joeblock");
 
     return postWithOkStatus(joeBlockId, "/users", user.encode());
+  }
+
+  private Future<Void> postUserWithCustomFields() {
+    log.info("Creating a new user\n");
+
+    JsonObject user = new JsonObject()
+      .put("id", johnRectangleId)
+      .put("active", true)
+      .put("username", "johnRectangle");
+    addCustomFields(user);
+
+    return postWithOkStatus(johnRectangleId, "/users", user.encode());
+  }
+
+  private static void addCustomFields(JsonObject u) {
+    JsonObject customFields = new JsonObject();
+    customFields.put("department_1", "Math");
+    u.put("customFields", customFields);
+  }
+
+  private Future<Void> getUserWithCustomFields(TestContext context) {
+    log.info("Retrieving a user with custom fields\n");
+
+    Future<JsonObject> future = getJson(context, "/users/" + johnRectangleId);
+
+    return future.map(user -> {
+      JsonObject customFields = user.getJsonObject("customFields");
+
+      if (customFields == null || !customFields.encode().equals("{\"department_1\":\"Math\"}")) {
+        fail("Bad value for customFields. " + encode(customFields));
+      }
+
+      return null;
+    });
+  }
+
+  private Future<Void> putUserWithNotExistingCustomField(TestContext context) {
+    log.info("Changing a user with not existing custom field");
+
+    JsonObject user = new JsonObject()
+      .put("username", "johnrectangle")
+      .put("id", johnRectangleId)
+      .put("active", true)
+      .put("personal", new JsonObject()
+        .put("lastName", "Rectangle")
+        .put("firstName", "John")
+      )
+      .put("customFields", new JsonObject()
+        .put(notExistingCustomField, "abc")
+      );
+
+    Future<HttpResponse<Buffer>> future = put("/users/" + johnRectangleId, encode(user));
+
+    return future.map(response -> {
+      RestITSupport.assertStatus(context, response, 422);
+
+      Errors errors = Json.decodeValue(response.body(), Errors.class);
+
+      Parameter errorParam = errors.getErrors().get(0).getParameters().get(0);
+
+      context.assertEquals("customFields", errorParam.getKey());
+      context.assertEquals(notExistingCustomField, errorParam.getValue());
+
+      return null;
+    });
+  }
+
+  private Future<Void> postUserWithNotExistingCustomField(TestContext context) {
+    log.info("Attempting to create a user with not existing custom field");
+
+    JsonObject user = new JsonObject()
+      .put("username", "johnrectangle")
+      .put("id", johnRectangleId)
+      .put("active", true)
+      .put("personal", new JsonObject()
+        .put("lastName", "Rectangle")
+        .put("firstName", "John")
+      )
+      .put("customFields", new JsonObject()
+        .put(notExistingCustomField, "abc")
+      );
+
+    Future<HttpResponse<Buffer>> future = post("/users", encode(user));
+
+    return future.map(response -> {
+      RestITSupport.assertStatus(context, response, 422);
+
+      Errors errors = Json.decodeValue(response.body(), Errors.class);
+      Parameter errorParam = errors.getErrors().get(0).getParameters().get(0);
+
+      context.assertEquals("customFields", errorParam.getKey());
+      context.assertEquals(notExistingCustomField, errorParam.getValue());
+
+      return null;
+    });
   }
 
   private Future<Void> assertCustomFieldValues(JsonObject result) {
@@ -183,5 +314,10 @@ public class CustomFieldIT {
   private Future<Void> putCustomField(TestContext context) {
     log.info("Update custom field definition\n");
     return putWithNoContentStatus(context, joeBlockId, customFieldsPath + "/" + customFieldId, putCustomField);
+  }
+
+  private Future<Void> deleteUser(TestContext context, String userId) {
+    log.info("Deleting existing user\n");
+    return deleteWithNoContentStatus(context, "/users/" + userId);
   }
 }

--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -122,9 +122,9 @@ public class CustomFieldIT {
 
   @Test
   public void test4CustomFields(TestContext context) {
-
     Async async = context.async();
-    postCustomField()
+    postUser()
+      .compose(v -> postCustomField())
       .compose(v -> putCustomField(context))
       .compose(v -> queryCustomField(context)).compose(this::assertCustomFieldValues)
       .compose(v -> deleteCustomField(context))
@@ -136,6 +136,17 @@ public class CustomFieldIT {
           context.fail(res.cause());
         }
       });
+  }
+
+  private Future<Void> postUser() {
+    log.info("Creating a new user\n");
+
+    JsonObject user = new JsonObject()
+      .put("id", joeBlockId)
+      .put("active", true)
+      .put("username", "joeblock");
+
+    return postWithOkStatus(joeBlockId, "/users", user.encode());
   }
 
   private Future<Void> assertCustomFieldValues(JsonObject result) {

--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import static org.folio.moduserstest.RestITSupport.deleteWithNoContentStatus;
-import static org.folio.moduserstest.RestITSupport.getByQuery;
+import static org.folio.moduserstest.RestITSupport.getJson;
 import static org.folio.moduserstest.RestITSupport.postWithOkStatus;
 import static org.folio.moduserstest.RestITSupport.putWithNoContentStatus;
 import static org.folio.util.StringUtil.urlEncode;
@@ -172,7 +172,7 @@ public class CustomFieldIT {
     String requestUrl = customFieldsPath + "?query=" + urlEncode("entityType==user");
     log.info("Getting custom field via CQL, by entityType\n");
 
-    return getByQuery(context, requestUrl);
+    return getJson(context, requestUrl);
   }
 
   private Future<Void> postCustomField() {

--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -124,7 +124,7 @@ public class CustomFieldIT {
   public void test4CustomFields(TestContext context) {
 
     Async async = context.async();
-    postCustomField(context)
+    postCustomField()
       .compose(v -> putCustomField(context))
       .compose(v -> queryCustomField(context)).compose(this::assertCustomFieldValues)
       .compose(v -> deleteCustomField(context))
@@ -154,33 +154,23 @@ public class CustomFieldIT {
 
   private Future<Void> deleteCustomField(TestContext context) {
     log.info("Deleting existing custom field\n");
-    Promise<Void> promise = Promise.promise();
-    deleteWithNoContentStatus(context, promise, customFieldsPath + "/" + customFieldId);
-    return promise.future();
+    return deleteWithNoContentStatus(context, customFieldsPath + "/" + customFieldId);
   }
 
   private Future<JsonObject> queryCustomField(TestContext context) {
     String requestUrl = customFieldsPath + "?query=" + urlEncode("entityType==user");
     log.info("Getting custom field via CQL, by entityType\n");
-    Promise<JsonObject> promise = Promise.promise();
-    try {
-      getByQuery(context, requestUrl, promise);
-    } catch (Exception e) {
-      promise.fail(e);
-    }
-    return promise.future();
+
+    return getByQuery(context, requestUrl);
   }
 
-  private Future<Void> postCustomField(TestContext context) {
+  private Future<Void> postCustomField() {
     log.info("Creating a new custom field definition\n");
-    Promise<Void> promise = Promise.promise();
-    postWithOkStatus(promise, joeBlockId, customFieldsPath, postCustomField);
-    return promise.future();
+    return postWithOkStatus(joeBlockId, customFieldsPath, postCustomField);
   }
 
   private Future<Void> putCustomField(TestContext context) {
     log.info("Update custom field definition\n");
-    Promise<Void> promise = Promise.promise();
-    return putWithNoContentStatus(context, promise, joeBlockId, customFieldsPath + "/" + customFieldId, putCustomField);
+    return putWithNoContentStatus(context, joeBlockId, customFieldsPath + "/" + customFieldId, putCustomField);
   }
 }

--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -1,0 +1,186 @@
+package org.folio.moduserstest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import static org.folio.moduserstest.RestITSupport.deleteWithNoContentStatus;
+import static org.folio.moduserstest.RestITSupport.getByQuery;
+import static org.folio.moduserstest.RestITSupport.postWithOkStatus;
+import static org.folio.moduserstest.RestITSupport.putWithNoContentStatus;
+import static org.folio.util.StringUtil.urlEncode;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+
+@RunWith(VertxUnitRunner.class)
+public class CustomFieldIT {
+
+  private static final Logger log = LoggerFactory.getLogger(CustomFieldIT.class);
+
+  private static final String joeBlockId = "ba6baf95-bf14-4020-b44c-0cad269fb5c9";
+
+  private static final String customFieldsPath = "/custom-fields";
+
+  private static final String customFieldId = "524d3210-9ca2-4f91-87b4-d2227d595aaa";
+
+  private static final String postCustomField = "{\"id\": \"524d3210-9ca2-4f91-87b4-d2227d595aaa\", " +
+    "\"name\": \"Department\", " +
+    "\"visible\": true, " +
+    "\"required\": true, " +
+    "\"helpText\": \"Provide a department\", " +
+    "\"entityType\": \"user\", " +
+    "\"type\": \"TEXTBOX_SHORT\", " +
+    "\"order\": 1, " +
+    "\"textField\": { \"maxSize\": 150 }}";
+  private static final String putCustomField = "{\"id\": \"524d3210-9ca2-4f91-87b4-d2227d595aaa\", " +
+    "\"name\": \"Department updated\", " +
+    "\"visible\": false, " +
+    "\"required\": true, " +
+    "\"helpText\": \"Provide a department\", " +
+    "\"entityType\": \"user\", " +
+    "\"type\": \"TEXTBOX_SHORT\", " +
+    "\"order\": 1, " +
+    "\"textField\": {   \"maxSize\": 250 }}";
+
+
+  @Rule
+  public Timeout rule = Timeout.seconds(20);
+
+  @BeforeClass
+  public static void setup(TestContext context) {
+    RestITSupport.setUp();
+
+    Async async = context.async();
+    TenantClient tenantClient = new TenantClient(RestITSupport.HTTP_LOCALHOST + RestITSupport.port(), "diku", "diku");
+    DeploymentOptions options = new DeploymentOptions()
+      .setConfig(new JsonObject().put("http.port", RestITSupport.port()))
+      .setWorker(true);
+
+    RestITSupport.vertx().deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess(res -> {
+      // remove existing schema from previous tests
+      tenantClient.deleteTenant(delete -> {
+        switch (delete.statusCode()) {
+          case 204: break;  // existing schema has been deleted
+          case 400: break;  // schema does not exist
+          default:
+            RestITSupport.fail(context, "deleteTenant", delete);
+            return;
+        }
+        try {
+          TenantAttributes ta = new TenantAttributes();
+          ta.setModuleTo("mod-users-1.0.0");
+          List<Parameter> parameters = new LinkedList<>();
+          parameters.add(new Parameter().withKey("loadReference").withValue("true"));
+          parameters.add(new Parameter().withKey("loadSample").withValue("false"));
+          ta.setParameters(parameters);
+          tenantClient.postTenant(ta, post -> {
+            if (post.statusCode() != 201) {
+              RestITSupport.fail(context, "postTenant", post);
+            }
+            async.complete();
+          });
+        } catch (Exception e) {
+          context.fail(e);
+        }
+      });
+    }));
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    RestITSupport.vertx().close(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      future.complete(null);
+    });
+    future.join();
+  }
+
+  @Test
+  public void test4CustomFields(TestContext context) {
+
+    Async async = context.async();
+    postCustomField(context)
+      .compose(v -> putCustomField(context))
+      .compose(v -> queryCustomField(context)).compose(this::assertCustomFieldValues)
+      .compose(v -> deleteCustomField(context))
+      .setHandler(res -> {
+        if (res.succeeded()) {
+          async.complete();
+        } else {
+          res.cause().printStackTrace();
+          context.fail(res.cause());
+        }
+      });
+  }
+
+  private Future<Void> assertCustomFieldValues(JsonObject result) {
+    Promise<Void> promise = Promise.promise();
+    int totalRecords = result.getInteger("totalRecords");
+    if (totalRecords != 1) {
+      promise.fail("Expected 1 record, got " + totalRecords);
+    }
+    JsonArray customFields = result.getJsonArray("customFields");
+    JsonObject customField = customFields.getJsonObject(0);
+    assertThat(customField.getString("entityType"), is("user"));
+
+    promise.complete();
+    return promise.future();
+  }
+
+  private Future<Void> deleteCustomField(TestContext context) {
+    log.info("Deleting existing custom field\n");
+    Promise<Void> promise = Promise.promise();
+    deleteWithNoContentStatus(context, promise, customFieldsPath + "/" + customFieldId);
+    return promise.future();
+  }
+
+  private Future<JsonObject> queryCustomField(TestContext context) {
+    String requestUrl = customFieldsPath + "?query=" + urlEncode("entityType==user");
+    log.info("Getting custom field via CQL, by entityType\n");
+    Promise<JsonObject> promise = Promise.promise();
+    try {
+      getByQuery(context, requestUrl, promise);
+    } catch (Exception e) {
+      promise.fail(e);
+    }
+    return promise.future();
+  }
+
+  private Future<Void> postCustomField(TestContext context) {
+    log.info("Creating a new custom field definition\n");
+    Promise<Void> promise = Promise.promise();
+    postWithOkStatus(promise, joeBlockId, customFieldsPath, postCustomField);
+    return promise.future();
+  }
+
+  private Future<Void> putCustomField(TestContext context) {
+    log.info("Update custom field definition\n");
+    Promise<Void> promise = Promise.promise();
+    return putWithNoContentStatus(context, promise, joeBlockId, customFieldsPath + "/" + customFieldId, putCustomField);
+  }
+}

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -166,12 +166,10 @@ public class GroupIT {
     String url6 = url + urlEncode("active=true sortBy username", "UTF-8");
     //non existant group - should be 0 results
     String url7 = url + urlEncode("username=jhandley2nd and patronGroup.group=abc* sortby patronGroup.group");
-    //query by tag, should get one record
-    String url8 = url + urlEncode("tags=foo");
 
-    String[] urls = new String[]{url0, url1, url2, url3, url4, url5, url6, url7, url8};
+    String[] urls = new String[]{url0, url1, url2, url3, url4, url5, url6, url7};
 
-    for (int i = 0; i < 9; i++) {
+    for (int i = 0; i < 8; i++) {
       String cqlURL = urls[i];
       CompletableFuture<Response> cf = send(cqlURL, GET, null, HTTPResponseHandlers.json());
 
@@ -181,7 +179,6 @@ public class GroupIT {
         + "\nStatus - " + cqlResponse.code + " at " + System.currentTimeMillis() + " for " + cqlURL + " (url" + (i) + ") : " + cqlResponse.body.toString());
       //requests should usually have 3 or 4 results
       switch (i) {
-        case 8:
         case 5:
           context.assertEquals(1, cqlResponse.body.getInteger("totalRecords"));
           break;

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -1,0 +1,605 @@
+package org.folio.moduserstest;
+
+import static io.vertx.core.http.HttpMethod.DELETE;
+import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.core.http.HttpMethod.POST;
+import static io.vertx.core.http.HttpMethod.PUT;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.folio.moduserstest.RestITSupport.HTTP_LOCALHOST;
+import static org.folio.moduserstest.RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF;
+import static org.folio.moduserstest.RestITSupport.SUPPORTED_CONTENT_TYPE_TEXT_DEF;
+import static org.folio.moduserstest.RestITSupport.fail;
+import static org.folio.util.StringUtil.urlEncode;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import io.vertx.core.Context;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.client.WebClient;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.parser.JsonPathParser;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.tools.utils.VertxUtils;
+import org.folio.rest.utils.ExpirationTool;
+
+
+@RunWith(VertxUnitRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class GroupIT {
+
+  private final String userUrl = HTTP_LOCALHOST + port + "/users";
+  private final String groupUrl = HTTP_LOCALHOST + port + "/groups";
+
+  private static final String fooGroupData = "{\"group\": \"librarianFOO\",\"desc\": \"yet another basic lib group\"}";
+  private static final String barGroupData = "{\"group\": \"librarianBAR\",\"desc\": \"and yet another basic lib group\"}";
+
+  private static final Logger log = LoggerFactory.getLogger(GroupIT.class);
+
+  private static Vertx vertx;
+  private static Context vertxContext;
+  private static WebClient client;
+  private static int port;
+
+  private static int userInc = 0;
+
+  @Rule
+  public Timeout rule = Timeout.seconds(20);
+
+
+  @BeforeClass
+  public static void setup(TestContext context) {
+    vertx = VertxUtils.getVertxWithExceptionHandler();
+    vertxContext = vertx.getOrCreateContext();
+
+    client = WebClient.create(vertx);
+
+    Async async = context.async();
+    port = NetworkUtils.nextFreePort();
+    TenantClient tenantClient = new TenantClient(HTTP_LOCALHOST + port, "diku", "diku");
+    DeploymentOptions options = new DeploymentOptions()
+      .setConfig(new JsonObject().put("http.port", port))
+      .setWorker(true);
+
+    vertx.deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess(res -> {
+      // remove existing schema from previous tests
+      tenantClient.deleteTenant(delete -> {
+        switch (delete.statusCode()) {
+          case 204: break;  // existing schema has been deleted
+          case 400: break;  // schema does not exist
+          default:
+            fail(context, "deleteTenant", delete);
+            return;
+        }
+        try {
+          TenantAttributes ta = new TenantAttributes();
+          ta.setModuleTo("mod-users-1.0.0");
+          List<Parameter> parameters = new LinkedList<>();
+          parameters.add(new Parameter().withKey("loadReference").withValue("true"));
+          parameters.add(new Parameter().withKey("loadSample").withValue("false"));
+          ta.setParameters(parameters);
+          tenantClient.postTenant(ta, post -> {
+            if (post.statusCode() != 201) {
+              fail(context, "postTenant", post);
+            }
+            async.complete();
+          });
+        } catch (Exception e) {
+          context.fail(e);
+        }
+      });
+    }));
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    vertx.close(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      future.complete(null);
+    });
+    future.join();
+  }
+
+  @Test
+  public void test3CrossTableQueries(TestContext context) throws Exception {
+    String url = HTTP_LOCALHOST + port + "/users?query=";
+
+    CompletableFuture<Response> postGroupCF = new CompletableFuture();
+    send(groupUrl, context, POST, barGroupData,  new HTTPResponseHandler(postGroupCF));
+    Response postGroupResponse = postGroupCF.get(5, SECONDS);
+    context.assertEquals(postGroupResponse.code, HTTP_CREATED);
+    String barGroupId = postGroupResponse.body.getString("id");
+    context.assertNotNull(barGroupId);
+
+    int inc = 0;
+    CompletableFuture<Response> addUserCF = new CompletableFuture();
+    send(userUrl, context, POST, createUser(null, "jhandley" + inc++, barGroupId).encode(),
+      new HTTPResponseHandler(addUserCF));
+    Response addUserResponse = addUserCF.get(5, SECONDS);
+    context.assertEquals(addUserResponse.code, HTTP_CREATED);
+    log.info(addUserResponse.body
+      + "\nStatus - " + addUserResponse.code + " at " + System.currentTimeMillis() + " for " + userUrl);
+
+    CompletableFuture<Response> addUserCF2 = new CompletableFuture();
+    send(userUrl, context, POST, createUser(null, "jhandley" + inc++, barGroupId).encode(),
+      new HTTPResponseHandler(addUserCF2));
+    Response addUserResponse2 = addUserCF2.get(5, SECONDS);
+    context.assertEquals(addUserResponse2.code, HTTP_CREATED);
+    log.info(addUserResponse2.body
+      + "\nStatus - " + addUserResponse2.code + " at " + System.currentTimeMillis() + " for " + userUrl);
+
+    //query on users and sort by groups
+    String url0 = userUrl;
+    String url1 = url + urlEncode("cql.allRecords=1 sortBy patronGroup.group/sort.descending");
+    //String url1 = userUrl;
+    String url2 = url + urlEncode("cql.allrecords=1 sortBy patronGroup.group/sort.ascending");
+    //query and sort on groups via users endpoint
+    String url3 = url + urlEncode("patronGroup.group=lib* sortBy patronGroup.group/sort.descending");
+    //query on users sort on users and groups
+    String url4 = url + urlEncode("cql.allrecords=1 sortby patronGroup.group personal.lastName personal.firstName");
+    //query on users and groups sort by groups
+    String url5 = url + urlEncode("username=jhandley2nd and patronGroup.group=lib* sortby patronGroup.group");
+    //query on users and sort by users
+    String url6 = url + urlEncode("active=true sortBy username", "UTF-8");
+    //non existant group - should be 0 results
+    String url7 = url + urlEncode("username=jhandley2nd and patronGroup.group=abc* sortby patronGroup.group");
+    //query by tag, should get one record
+    String url8 = url + urlEncode("tags=foo");
+
+    CompletableFuture<Response> cqlCF0 = new CompletableFuture();
+    CompletableFuture<Response> cqlCF1 = new CompletableFuture();
+    CompletableFuture<Response> cqlCF2 = new CompletableFuture();
+    CompletableFuture<Response> cqlCF3 = new CompletableFuture();
+    CompletableFuture<Response> cqlCF4 = new CompletableFuture();
+    CompletableFuture<Response> cqlCF5 = new CompletableFuture();
+    CompletableFuture<Response> cqlCF6 = new CompletableFuture();
+    CompletableFuture<Response> cqlCF7 = new CompletableFuture();
+    CompletableFuture<Response> cqlCF8 = new CompletableFuture();
+
+    String[] urls = new String[]{url0, url1, url2, url3, url4, url5, url6, url7, url8};
+    CompletableFuture<Response>[] cqlCF = new CompletableFuture[]{cqlCF0, cqlCF1, cqlCF2, cqlCF3, cqlCF4, cqlCF5, cqlCF6, cqlCF7, cqlCF8};
+
+    for (int i = 0; i < 9; i++) {
+      CompletableFuture<Response> cf = cqlCF[i];
+      String cqlURL = urls[i];
+      send(cqlURL, context, GET, null,  new HTTPResponseHandler(cf));
+      Response cqlResponse = cf.get(5, SECONDS);
+      context.assertEquals(cqlResponse.code, HTTP_OK);
+      log.info(cqlResponse.body
+        + "\nStatus - " + cqlResponse.code + " at " + System.currentTimeMillis() + " for " + cqlURL + " (url" + (i) + ") : " + cqlResponse.body.toString());
+      //requests should usually have 3 or 4 results
+      switch (i) {
+        case 8:
+          context.assertEquals(1, cqlResponse.body.getInteger("totalRecords"));
+          break;
+        case 7:
+          context.assertEquals(0, cqlResponse.body.getInteger("totalRecords"));
+          break;
+        case 6:
+          context.assertTrue(cqlResponse.body.getInteger("totalRecords") > 2);
+          break;
+        case 5:
+          context.assertEquals(1, cqlResponse.body.getInteger("totalRecords"));
+          break;
+        case 1:
+          context.assertTrue(cqlResponse.body.getInteger("totalRecords") > 1);
+          context.assertEquals("jhandley2nd", cqlResponse.body.getJsonArray("users").getJsonObject(0).getString("username"));
+          break;
+        case 2:
+          context.assertNotEquals("jhandley2nd", cqlResponse.body.getJsonArray("users").getJsonObject(0).getString("username"));
+          break;
+        case 4:
+          context.assertTrue(((String) (new JsonPathParser(cqlResponse.body).getValueAt("users[0].personal.lastName"))).startsWith("Triangle"));
+          break;
+        case 0:
+          //Baseline test
+          int totalRecords = cqlResponse.body.getInteger("totalRecords");
+          context.assertTrue(totalRecords > 3, "totalRecords = " + totalRecords + " > 3");
+          break;
+        default:
+          context.assertInRange(2, cqlResponse.body.getInteger("totalRecords"), 2);
+          break;
+      }
+    }
+  }
+
+  @Test
+  public void test2Group(TestContext context) throws Exception {
+
+    /**
+     * add a group
+     */
+    CompletableFuture<Response> addGroupCF = new CompletableFuture();
+    send(groupUrl, context, POST, fooGroupData,  new HTTPResponseHandler(addGroupCF));
+    Response addGroupResponse = addGroupCF.get(5, SECONDS);
+    context.assertEquals(addGroupResponse.code, HTTP_CREATED);
+    String groupID1 = addGroupResponse.body.getString("id");
+    log.info(addGroupResponse.body
+      + "\nStatus - " + addGroupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
+
+    /**
+     * update a group
+     */
+    CompletableFuture<Response> updateGroupCF = new CompletableFuture();
+    String updateGroupURL = groupUrl + "/" + groupID1;
+    send(updateGroupURL, context, PUT, barGroupData, new HTTPNoBodyResponseHandler(updateGroupCF));
+    Response updateGroupResponse = updateGroupCF.get(5, SECONDS);
+    context.assertEquals(updateGroupResponse.code, HTTP_NO_CONTENT);
+    log.info(updateGroupResponse.body
+      + "\nStatus - " + updateGroupResponse.code + " at " + System.currentTimeMillis() + " for " + updateGroupURL);
+
+    /**
+     * delete a group
+     */
+    CompletableFuture<Response> deleteCleanCF = new CompletableFuture();
+    String deleteCleanURL = groupUrl + "/" + groupID1;
+    send(deleteCleanURL, context, DELETE, null, new HTTPNoBodyResponseHandler(deleteCleanCF));
+    Response deleteCleanResponse = deleteCleanCF.get(5, SECONDS);
+    context.assertEquals(deleteCleanResponse.code, HTTP_NO_CONTENT);
+    log.info(deleteCleanResponse.body
+      + "\nStatus - " + deleteCleanResponse.code + " at " + System.currentTimeMillis() + " for " + deleteCleanURL);
+
+    /**
+     * re-add a group
+     */
+    CompletableFuture<Response> addNewGroupCF = new CompletableFuture();
+    send(groupUrl, context, POST, fooGroupData, new HTTPResponseHandler(addNewGroupCF));
+    Response addNewGroupResponse = addNewGroupCF.get(5, SECONDS);
+    context.assertEquals(addNewGroupResponse.code, HTTP_CREATED);
+    groupID1 = addNewGroupResponse.body.getString("id");
+    log.info(addNewGroupResponse.body
+      + "\nStatus - " + addNewGroupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
+
+    /**
+     * add a user
+     */
+    CompletableFuture<Response> addUserCF = new CompletableFuture();
+    String addUserURL = userUrl;
+    send(addUserURL, context, POST, createUser(null, "jhandley", groupID1).encode(),
+      new HTTPResponseHandler(addUserCF));
+    Response addUserResponse = addUserCF.get(5, SECONDS);
+    context.assertEquals(addUserResponse.code, HTTP_CREATED);
+    String userID = addUserResponse.body.getString("id");
+    log.info(addUserResponse.body
+      + "\nStatus - " + addUserResponse.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
+
+    /**
+     * add the same user name again
+     */
+    CompletableFuture<Response> addUserCF2 = new CompletableFuture();
+    send(addUserURL, context, POST, createUser(null, "jhandley", groupID1).encode(),
+      new HTTPResponseHandler(addUserCF2));
+    Response addUserResponse2 = addUserCF2.get(5, SECONDS);
+    context.assertEquals(addUserResponse2.code, 422);
+    log.info(addUserResponse2.body
+      + "\nStatus - " + addUserResponse2.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
+
+    /**
+     * add the same user again with same id
+     */
+    CompletableFuture<Response> addUserCF3 = new CompletableFuture();
+    send(addUserURL, context, POST, createUser(userID, "jhandley", groupID1).encode(),
+      new HTTPResponseHandler(addUserCF3));
+    Response addUserResponse3 = addUserCF3.get(5, SECONDS);
+    context.assertEquals(addUserResponse3.code, 422);
+    log.info(addUserResponse3.body
+      + "\nStatus - " + addUserResponse3.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
+
+    /**
+     * add a user again with non existent patron group
+     */
+    CompletableFuture<Response> addUserCF4 = new CompletableFuture();
+    send(addUserURL, context, POST, createUser(null, "jhandley2nd", "10c19698-313b-46fc-8d4b-2d00c6958f5d").encode(),
+      new HTTPNoBodyResponseHandler(addUserCF4));
+    Response addUserResponse4 = addUserCF4.get(5, SECONDS);
+    context.assertEquals(addUserResponse4.code, HTTP_BAD_REQUEST);
+    log.info(addUserResponse4.body
+      + "\nStatus - " + addUserResponse4.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
+
+    /**
+     * add a user again with invalid uuid
+     */
+    CompletableFuture<Response> addUserCF4a = new CompletableFuture();
+    send(addUserURL, context, POST, createUser(null, "jhandley2nd", "invalid-uuid").encode(),
+      new HTTPNoBodyResponseHandler(addUserCF4a));
+    Response addUserResponse4a = addUserCF4a.get(5, SECONDS);
+    context.assertEquals(addUserResponse4a.code, HTTP_BAD_REQUEST);
+    log.info(addUserResponse4a.body
+      + "\nStatus - " + addUserResponse4a.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
+
+    /**
+     * update a user again with non existent patron group
+     */
+    CompletableFuture<Response> updateUserCF = new CompletableFuture();
+    send(addUserURL + "/" + userID, context, PUT, createUser(userID, "jhandley2nd",
+      "20c19698-313b-46fc-8d4b-2d00c6958f5d").encode(), new HTTPNoBodyResponseHandler(updateUserCF));
+    Response updateUserResponse = updateUserCF.get(5, SECONDS);
+    context.assertEquals(updateUserResponse.code, HTTP_BAD_REQUEST);
+    log.info(updateUserResponse.body
+      + "\nStatus - " + updateUserResponse.code + " at " + System.currentTimeMillis() + " for " + addUserURL + "/" + userID);
+
+    /**
+     * update a user again with existent patron group
+     */
+    CompletableFuture<Response> updateUser2CF = new CompletableFuture();
+    send(addUserURL + "/" + userID, context, PUT, createUser(userID, "jhandley2nd", groupID1).encode(),
+      new HTTPNoBodyResponseHandler(updateUser2CF));
+    Response updateUser2Response = updateUser2CF.get(5, SECONDS);
+    context.assertEquals(updateUser2Response.code, HTTP_NO_CONTENT);
+    log.info(updateUser2Response.body
+      + "\nStatus - " + updateUser2Response.code + " at " + System.currentTimeMillis() + " for " + addUserURL + "/" + userID);
+
+    /**
+     * get all users belonging to a specific group
+     */
+    CompletableFuture<Response> getUsersInGroupCF = new CompletableFuture();
+    String getUsersInGroupURL = userUrl + "?query=patronGroup==" + groupID1;
+    send(getUsersInGroupURL, context, GET, null,
+      new HTTPResponseHandler(getUsersInGroupCF));
+    Response getUsersInGroupResponse = getUsersInGroupCF.get(5, SECONDS);
+    context.assertEquals(getUsersInGroupResponse.code, HTTP_OK);
+    log.info(getUsersInGroupResponse.body
+      + "\nStatus - " + getUsersInGroupResponse.code + " at " + System.currentTimeMillis() + " for "
+      + getUsersInGroupURL);
+    context.assertTrue(isSizeMatch(getUsersInGroupResponse, 1));
+
+    /**
+     * get all groups in groups table
+     */
+    CompletableFuture<Response> getAllGroupCF = new CompletableFuture();
+    send(groupUrl, context, GET, null, new HTTPResponseHandler(getAllGroupCF));
+    Response getAllGroupResponse = getAllGroupCF.get(5, SECONDS);
+    context.assertEquals(getAllGroupResponse.code, HTTP_OK);
+    log.info(getAllGroupResponse.body
+      + "\nStatus - " + getAllGroupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
+    context.assertTrue(isSizeMatch(getAllGroupResponse, 5)); // 4 in reference + 1 in test
+
+    /**
+     * try to get via cql
+     */
+    CompletableFuture<Response> cqlCF = new CompletableFuture();
+    String cqlURL = groupUrl + "?query=group==librarianFOO";
+    send(cqlURL, context, GET, null, new HTTPResponseHandler(cqlCF));
+    Response cqlResponse = cqlCF.get(5, SECONDS);
+    context.assertEquals(cqlResponse.code, HTTP_OK);
+    log.info(cqlResponse.body
+      + "\nStatus - " + cqlResponse.code + " at " + System.currentTimeMillis() + " for " + cqlURL);
+    context.assertTrue(isSizeMatch(cqlResponse, 1));
+
+    /**
+     * delete a group - should fail as there is a user associated with the group
+     */
+    CompletableFuture<Response> delete1CF = new CompletableFuture();
+    String delete1URL = groupUrl + "/" + groupID1;
+    send(delete1URL, context, DELETE, null, new HTTPNoBodyResponseHandler(delete1CF));
+    Response delete1Response = delete1CF.get(5, SECONDS);
+    context.assertEquals(delete1Response.code, HTTP_BAD_REQUEST);
+    log.info(delete1Response.body
+      + "\nStatus - " + delete1Response.code + " at " + System.currentTimeMillis() + " for " + delete1URL);
+
+    /**
+     * delete a nonexistent group - should return 404
+     */
+    CompletableFuture<Response> deleteNEGCF = new CompletableFuture();
+    String deleteNEGURL = groupUrl + "/a492ffd2-b848-48bf-b716-1a645822279e";
+    send(deleteNEGURL, context, DELETE, null, new HTTPNoBodyResponseHandler(deleteNEGCF));
+    Response deleteNEGResponse = deleteNEGCF.get(5, SECONDS);
+    context.assertEquals(deleteNEGResponse.code, HTTP_NOT_FOUND);
+    log.info(deleteNEGResponse.body
+      + "\nStatus - " + deleteNEGResponse.code + " at " + System.currentTimeMillis() + " for " + deleteNEGURL);
+
+    /**
+     * try to add a duplicate group
+     */
+    CompletableFuture<Response> dupCF = new CompletableFuture();
+    send(groupUrl, context, POST, fooGroupData, new HTTPResponseHandler(dupCF));
+    Response dupResponse = dupCF.get(5, SECONDS);
+    context.assertEquals(dupResponse.code, 422);
+    log.info(dupResponse.body
+      + "\nStatus - " + dupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
+
+    /**
+     * get a group
+     */
+    CompletableFuture<Response> getSpecGroupCF = new CompletableFuture();
+    String getSpecGroupURL = groupUrl + "/" + groupID1;
+    send(getSpecGroupURL, context, GET, null,  new HTTPResponseHandler(getSpecGroupCF));
+    Response getSpecGroupResponse = getSpecGroupCF.get(5, SECONDS);
+    context.assertEquals(getSpecGroupResponse.code, HTTP_OK);
+    log.info(getSpecGroupResponse.body
+      + "\nStatus - " + getSpecGroupResponse.code + " at " + System.currentTimeMillis() + " for " + getSpecGroupURL);
+    context.assertTrue("librarianFOO".equals(getSpecGroupResponse.body.getString("group")));
+
+    /**
+     * get a group bad id
+     */
+    CompletableFuture<Response> getBadIDCF = new CompletableFuture();
+    String getBadIDURL = groupUrl + "/3748ec8d-8dbc-4717-819d-87c839e6905e";
+    send(getBadIDURL, context, GET, null, new HTTPNoBodyResponseHandler(getBadIDCF));
+    Response getBadIDResponse = getBadIDCF.get(5, SECONDS);
+    context.assertEquals(getBadIDResponse.code, HTTP_NOT_FOUND);
+    log.info(getBadIDResponse.body
+      + "\nStatus - " + getBadIDResponse.code + " at " + System.currentTimeMillis() + " for " + getBadIDURL);
+
+    /**
+     * delete a group with users should fail
+     */
+    CompletableFuture<Response> deleteCF = new CompletableFuture();
+    String delete = groupUrl + "/" + groupID1;
+    send(delete, context, DELETE, null, new HTTPNoBodyResponseHandler(deleteCF));
+    Response deleteResponse = deleteCF.get(5, SECONDS);
+    context.assertEquals(deleteResponse.code, HTTP_BAD_REQUEST);
+    log.info(deleteResponse.body
+      + "\nStatus - " + deleteResponse.code + " at " + System.currentTimeMillis() + " for " + delete);
+
+    /* Create a user with a past-due expiration date */
+    UUID expiredUserId = UUID.randomUUID();
+    {
+      Date now = new Date();
+      Date pastDate = new Date(now.getTime() - (10 * 24 * 60 * 60 * 1000));
+      String dateString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS\'Z\'").format(pastDate);
+      JsonObject expiredUserJson = new JsonObject()
+        .put("id", expiredUserId.toString())
+        .put("username", "bmoses")
+        .put("patronGroup", groupID1)
+        .put("active", true)
+        .put("expirationDate", dateString)
+        .put("personal", new JsonObject()
+          .put("lastName", "Brown")
+          .put("firstName", "Moses")
+        );
+      CompletableFuture<Response> addExpiredUserCF = new CompletableFuture();
+      send(addUserURL, context, POST, expiredUserJson.encode(), new HTTPResponseHandler(addExpiredUserCF));
+      Response addExpiredUserResponse = addExpiredUserCF.get(5, SECONDS);
+      log.info(addExpiredUserResponse.body
+        + "\nStatus - " + addExpiredUserResponse.code + " at "
+        + System.currentTimeMillis() + " for " + addUserURL + " (addExpiredUser)");
+      context.assertEquals(addExpiredUserResponse.code, 201);
+      CompletableFuture<Void> getExpirationCF = new CompletableFuture();
+      ExpirationTool.doExpirationForTenant(vertx, vertxContext, "diku").setHandler(res -> {
+        getExpirationCF.complete(null);
+      });
+      getExpirationCF.get(5, SECONDS);
+      //TimeUnit.SECONDS.sleep(15);
+      CompletableFuture<Response> getExpiredUserCF = new CompletableFuture();
+      send(addUserURL + "/" + expiredUserId.toString(), context, GET, null,
+        new HTTPResponseHandler(getExpiredUserCF));
+      Response getExpiredUserResponse = getExpiredUserCF.get(5, SECONDS);
+      context.assertEquals(getExpiredUserResponse.body.getBoolean("active"), false);
+    }
+  }
+
+  private void send(String url, TestContext context, HttpMethod method, String content, Handler<HttpClientResponse> handler) {
+    HttpClient client = vertx.createHttpClient();
+    HttpClientRequest request;
+    if (content == null) {
+      content = "";
+    }
+    Buffer buffer = Buffer.buffer(content);
+
+    if (method == POST) {
+      request = client.postAbs(url);
+    } else if (method == DELETE) {
+      request = client.deleteAbs(url);
+    } else if (method == GET) {
+      request = client.getAbs(url);
+    } else {
+      request = client.putAbs(url);
+    }
+    request.exceptionHandler(error -> {
+      context.fail(error.getMessage());
+    })
+      .handler(handler);
+    //request.putHeader("Authorization", "diku");
+    request.putHeader("x-okapi-tenant", "diku");
+    request.putHeader("Accept", SUPPORTED_CONTENT_TYPE_JSON_DEF);
+    request.putHeader("Accept", SUPPORTED_CONTENT_TYPE_TEXT_DEF);
+    request.putHeader("Content-type", SUPPORTED_CONTENT_TYPE_JSON_DEF);
+    request.end(buffer);
+  }
+
+  private static JsonObject createUser(String id, String name, String pgId) {
+    userInc++;
+    JsonObject user = new JsonObject();
+    if (id != null) {
+      user.put("id", id);
+    } else {
+      id = UUID.randomUUID().toString();
+      user.put("id", id);
+    }
+    user.put("username", name);
+    user.put("patronGroup", pgId);
+    user.put("active", true);
+    user.put("personal", new JsonObject()
+      .put("lastName", "Triangle" + userInc)
+      .put("firstName", "Jack" + userInc)
+    );
+    return user;
+  }
+
+  private boolean isSizeMatch(Response r, int size) {
+    if (r.body.getInteger("totalRecords") == size) {
+      return true;
+    }
+    return false;
+  }
+
+  class HTTPResponseHandler implements Handler<HttpClientResponse> {
+
+    CompletableFuture<Response> event;
+
+    public HTTPResponseHandler(CompletableFuture<Response> cf) {
+      event = cf;
+    }
+
+    @Override
+    public void handle(HttpClientResponse hcr) {
+      hcr.bodyHandler(bh -> {
+        Response r = new Response();
+        r.code = hcr.statusCode();
+        r.body = bh.toJsonObject();
+        event.complete(r);
+      });
+    }
+  }
+
+  class HTTPNoBodyResponseHandler implements Handler<HttpClientResponse> {
+
+    CompletableFuture<Response> event;
+
+    public HTTPNoBodyResponseHandler(CompletableFuture<Response> cf) {
+      event = cf;
+    }
+
+    @Override
+    public void handle(HttpClientResponse hcr) {
+      Response r = new Response();
+      r.code = hcr.statusCode();
+      event.complete(r);
+    }
+  }
+
+  class Response {
+
+    int code;
+    JsonObject body;
+  }
+
+}

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -10,25 +10,11 @@ import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static org.folio.moduserstest.RestITSupport.HTTP_LOCALHOST;
-import static org.folio.moduserstest.RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF;
-import static org.folio.moduserstest.RestITSupport.SUPPORTED_CONTENT_TYPE_TEXT_DEF;
 import static org.folio.moduserstest.RestITSupport.fail;
 import static org.folio.util.StringUtil.urlEncode;
-
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
@@ -37,6 +23,20 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.client.WebClient;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.parser.JsonPathParser;
+import org.folio.rest.utils.ExpirationTool;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -45,14 +45,6 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
-
-import org.folio.rest.RestVerticle;
-import org.folio.rest.client.TenantClient;
-import org.folio.rest.jaxrs.model.Parameter;
-import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.tools.parser.JsonPathParser;
-import org.folio.rest.utils.ExpirationTool;
 
 
 @RunWith(VertxUnitRunner.class)
@@ -228,8 +220,8 @@ public class GroupIT {
   @Test
   public void test2Group(TestContext context) throws Exception {
 
-    /**
-     * add a group
+    /*
+      add a group
      */
     CompletableFuture<Response> addGroupCF = new CompletableFuture();
     send(groupUrl, context, POST, fooGroupData, new HTTPResponseHandler(addGroupCF));
@@ -239,8 +231,8 @@ public class GroupIT {
     log.info(addGroupResponse.body
       + "\nStatus - " + addGroupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
 
-    /**
-     * update a group
+    /*
+      update a group
      */
     CompletableFuture<Response> updateGroupCF = new CompletableFuture();
     String updateGroupURL = groupUrl + "/" + groupID1;
@@ -250,8 +242,8 @@ public class GroupIT {
     log.info(updateGroupResponse.body
       + "\nStatus - " + updateGroupResponse.code + " at " + System.currentTimeMillis() + " for " + updateGroupURL);
 
-    /**
-     * delete a group
+    /*
+      delete a group
      */
     CompletableFuture<Response> deleteCleanCF = new CompletableFuture();
     String deleteCleanURL = groupUrl + "/" + groupID1;
@@ -261,8 +253,8 @@ public class GroupIT {
     log.info(deleteCleanResponse.body
       + "\nStatus - " + deleteCleanResponse.code + " at " + System.currentTimeMillis() + " for " + deleteCleanURL);
 
-    /**
-     * re-add a group
+    /*
+      re-add a group
      */
     CompletableFuture<Response> addNewGroupCF = new CompletableFuture();
     send(groupUrl, context, POST, fooGroupData, new HTTPResponseHandler(addNewGroupCF));
@@ -272,8 +264,8 @@ public class GroupIT {
     log.info(addNewGroupResponse.body
       + "\nStatus - " + addNewGroupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
 
-    /**
-     * add a user
+    /*
+      add a user
      */
     CompletableFuture<Response> addUserCF = new CompletableFuture();
     String addUserURL = userUrl;
@@ -285,8 +277,8 @@ public class GroupIT {
     log.info(addUserResponse.body
       + "\nStatus - " + addUserResponse.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
 
-    /**
-     * add the same user name again
+    /*
+      add the same user name again
      */
     CompletableFuture<Response> addUserCF2 = new CompletableFuture();
     send(addUserURL, context, POST, createUser(null, "jhandley", groupID1).encode(),
@@ -296,8 +288,8 @@ public class GroupIT {
     log.info(addUserResponse2.body
       + "\nStatus - " + addUserResponse2.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
 
-    /**
-     * add the same user again with same id
+    /*
+      add the same user again with same id
      */
     CompletableFuture<Response> addUserCF3 = new CompletableFuture();
     send(addUserURL, context, POST, createUser(userID, "jhandley", groupID1).encode(),
@@ -307,8 +299,8 @@ public class GroupIT {
     log.info(addUserResponse3.body
       + "\nStatus - " + addUserResponse3.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
 
-    /**
-     * add a user again with non existent patron group
+    /*
+      add a user again with non existent patron group
      */
     CompletableFuture<Response> addUserCF4 = new CompletableFuture();
     send(addUserURL, context, POST, createUser(null, "jhandley2nd", "10c19698-313b-46fc-8d4b-2d00c6958f5d").encode(),
@@ -318,8 +310,8 @@ public class GroupIT {
     log.info(addUserResponse4.body
       + "\nStatus - " + addUserResponse4.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
 
-    /**
-     * add a user again with invalid uuid
+    /*
+      add a user again with invalid uuid
      */
     CompletableFuture<Response> addUserCF4a = new CompletableFuture();
     send(addUserURL, context, POST, createUser(null, "jhandley2nd", "invalid-uuid").encode(),
@@ -329,8 +321,8 @@ public class GroupIT {
     log.info(addUserResponse4a.body
       + "\nStatus - " + addUserResponse4a.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
 
-    /**
-     * update a user again with non existent patron group
+    /*
+      update a user again with non existent patron group
      */
     CompletableFuture<Response> updateUserCF = new CompletableFuture();
     send(addUserURL + "/" + userID, context, PUT, createUser(userID, "jhandley2nd",
@@ -340,8 +332,8 @@ public class GroupIT {
     log.info(updateUserResponse.body
       + "\nStatus - " + updateUserResponse.code + " at " + System.currentTimeMillis() + " for " + addUserURL + "/" + userID);
 
-    /**
-     * update a user again with existent patron group
+    /*
+      update a user again with existent patron group
      */
     CompletableFuture<Response> updateUser2CF = new CompletableFuture();
     send(addUserURL + "/" + userID, context, PUT, createUser(userID, "jhandley2nd", groupID1).encode(),
@@ -351,8 +343,8 @@ public class GroupIT {
     log.info(updateUser2Response.body
       + "\nStatus - " + updateUser2Response.code + " at " + System.currentTimeMillis() + " for " + addUserURL + "/" + userID);
 
-    /**
-     * get all users belonging to a specific group
+    /*
+      get all users belonging to a specific group
      */
     CompletableFuture<Response> getUsersInGroupCF = new CompletableFuture();
     String getUsersInGroupURL = userUrl + "?query=patronGroup==" + groupID1;
@@ -365,8 +357,8 @@ public class GroupIT {
       + getUsersInGroupURL);
     context.assertTrue(isSizeMatch(getUsersInGroupResponse, 1));
 
-    /**
-     * get all groups in groups table
+    /*
+      get all groups in groups table
      */
     CompletableFuture<Response> getAllGroupCF = new CompletableFuture();
     send(groupUrl, context, GET, null, new HTTPResponseHandler(getAllGroupCF));
@@ -376,8 +368,8 @@ public class GroupIT {
       + "\nStatus - " + getAllGroupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
     context.assertTrue(isSizeMatch(getAllGroupResponse, 5)); // 4 in reference + 1 in test
 
-    /**
-     * try to get via cql
+    /*
+      try to get via cql
      */
     CompletableFuture<Response> cqlCF = new CompletableFuture();
     String cqlURL = groupUrl + "?query=group==librarianFOO";
@@ -388,8 +380,8 @@ public class GroupIT {
       + "\nStatus - " + cqlResponse.code + " at " + System.currentTimeMillis() + " for " + cqlURL);
     context.assertTrue(isSizeMatch(cqlResponse, 1));
 
-    /**
-     * delete a group - should fail as there is a user associated with the group
+    /*
+      delete a group - should fail as there is a user associated with the group
      */
     CompletableFuture<Response> delete1CF = new CompletableFuture();
     String delete1URL = groupUrl + "/" + groupID1;
@@ -399,8 +391,8 @@ public class GroupIT {
     log.info(delete1Response.body
       + "\nStatus - " + delete1Response.code + " at " + System.currentTimeMillis() + " for " + delete1URL);
 
-    /**
-     * delete a nonexistent group - should return 404
+    /*
+      delete a nonexistent group - should return 404
      */
     CompletableFuture<Response> deleteNEGCF = new CompletableFuture();
     String deleteNEGURL = groupUrl + "/a492ffd2-b848-48bf-b716-1a645822279e";
@@ -410,8 +402,8 @@ public class GroupIT {
     log.info(deleteNEGResponse.body
       + "\nStatus - " + deleteNEGResponse.code + " at " + System.currentTimeMillis() + " for " + deleteNEGURL);
 
-    /**
-     * try to add a duplicate group
+    /*
+      try to add a duplicate group
      */
     CompletableFuture<Response> dupCF = new CompletableFuture();
     send(groupUrl, context, POST, fooGroupData, new HTTPResponseHandler(dupCF));
@@ -420,8 +412,8 @@ public class GroupIT {
     log.info(dupResponse.body
       + "\nStatus - " + dupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
 
-    /**
-     * get a group
+    /*
+      get a group
      */
     CompletableFuture<Response> getSpecGroupCF = new CompletableFuture();
     String getSpecGroupURL = groupUrl + "/" + groupID1;
@@ -432,8 +424,8 @@ public class GroupIT {
       + "\nStatus - " + getSpecGroupResponse.code + " at " + System.currentTimeMillis() + " for " + getSpecGroupURL);
     context.assertTrue("librarianFOO".equals(getSpecGroupResponse.body.getString("group")));
 
-    /**
-     * get a group bad id
+    /*
+      get a group bad id
      */
     CompletableFuture<Response> getBadIDCF = new CompletableFuture();
     String getBadIDURL = groupUrl + "/3748ec8d-8dbc-4717-819d-87c839e6905e";
@@ -443,8 +435,8 @@ public class GroupIT {
     log.info(getBadIDResponse.body
       + "\nStatus - " + getBadIDResponse.code + " at " + System.currentTimeMillis() + " for " + getBadIDURL);
 
-    /**
-     * delete a group with users should fail
+    /*
+      delete a group with users should fail
      */
     CompletableFuture<Response> deleteCF = new CompletableFuture();
     String delete = groupUrl + "/" + groupID1;
@@ -459,7 +451,7 @@ public class GroupIT {
     {
       Date now = new Date();
       Date pastDate = new Date(now.getTime() - (10 * 24 * 60 * 60 * 1000));
-      String dateString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS\'Z\'").format(pastDate);
+      String dateString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(pastDate);
       JsonObject expiredUserJson = new JsonObject()
         .put("id", expiredUserId.toString())
         .put("username", "bmoses")
@@ -478,9 +470,8 @@ public class GroupIT {
         + System.currentTimeMillis() + " for " + addUserURL + " (addExpiredUser)");
       context.assertEquals(addExpiredUserResponse.code, 201);
       CompletableFuture<Void> getExpirationCF = new CompletableFuture();
-      ExpirationTool.doExpirationForTenant(RestITSupport.vertx(), RestITSupport.context(), "diku").setHandler(res -> {
-        getExpirationCF.complete(null);
-      });
+      ExpirationTool.doExpirationForTenant(RestITSupport.vertx(), RestITSupport.context(), "diku").setHandler(
+        res -> getExpirationCF.complete(null));
       getExpirationCF.get(5, SECONDS);
       //TimeUnit.SECONDS.sleep(15);
       CompletableFuture<Response> getExpiredUserCF = new CompletableFuture();
@@ -492,7 +483,7 @@ public class GroupIT {
   }
 
   private void send(String url, TestContext context, HttpMethod method, String content, Handler<HttpClientResponse> handler) {
-    HttpClient client = RestITSupport.vertx().createHttpClient();
+    /*HttpClient client = RestITSupport.vertx().createHttpClient();
     HttpClientRequest request;
     if (content == null) {
       content = "";
@@ -508,16 +499,16 @@ public class GroupIT {
     } else {
       request = client.putAbs(url);
     }
-    request.exceptionHandler(error -> {
-      context.fail(error.getMessage());
-    })
+    request.exceptionHandler(error -> context.fail(error.getMessage()))
       .handler(handler);
     //request.putHeader("Authorization", "diku");
     request.putHeader("x-okapi-tenant", "diku");
     request.putHeader("Accept", SUPPORTED_CONTENT_TYPE_JSON_DEF);
     request.putHeader("Accept", SUPPORTED_CONTENT_TYPE_TEXT_DEF);
     request.putHeader("Content-type", SUPPORTED_CONTENT_TYPE_JSON_DEF);
-    request.end(buffer);
+    request.end(buffer);*/
+
+    WebClient client = RestITSupport.webClient();
   }
 
   private static JsonObject createUser(String id, String name, String pgId) {

--- a/src/test/java/org/folio/moduserstest/RestITSupport.java
+++ b/src/test/java/org/folio/moduserstest/RestITSupport.java
@@ -29,6 +29,9 @@ import junit.framework.AssertionFailedError;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.rest.tools.utils.VertxUtils;
 
+/**
+ * For new tests consider using RestAssured instead of legacy RestITSupport.
+ */
 class RestITSupport {
 
   static final String SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";

--- a/src/test/java/org/folio/moduserstest/RestITSupport.java
+++ b/src/test/java/org/folio/moduserstest/RestITSupport.java
@@ -1,0 +1,82 @@
+package org.folio.moduserstest;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.web.client.HttpResponse;
+import java.util.Arrays;
+import junit.framework.AssertionFailedError;
+
+class RestITSupport {
+
+  static final String SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";
+  static final String SUPPORTED_CONTENT_TYPE_TEXT_DEF = "text/plain";
+  static final String HTTP_LOCALHOST = "http://localhost:";
+
+  RestITSupport() {
+  }
+
+  static void fail(TestContext context, HttpClientResponse response) {
+    StackTraceElement [] stacktrace = new Throwable().getStackTrace();
+    // remove the element with this fail method from the stacktrace
+    fail(context, null, response, Arrays.copyOfRange(stacktrace, 1, stacktrace.length));
+  }
+
+  static void fail(TestContext context, String message, HttpClientResponse response) {
+    StackTraceElement [] stacktrace = new Throwable().getStackTrace();
+    // remove the element with this fail method from the stacktrace
+    fail(context, message, response, Arrays.copyOfRange(stacktrace, 1, stacktrace.length));
+  }
+
+  static void fail(TestContext context, String message, HttpClientResponse response,
+                           StackTraceElement [] stacktrace) {
+    Async async = context.async();
+    response.bodyHandler(body -> {
+      Throwable t = new AssertionFailedError((message == null ? "" : message + ": ")
+          + response.statusCode() + " " + response.statusMessage() + " " + body.toString());
+      // t contains the stacktrace of bodyHandler but does not contain the method that
+      // called this fail method. Therefore exchange the stacktrace:
+      t.setStackTrace(stacktrace);
+      context.fail(t);
+      async.complete();
+    });
+  }
+
+  static void fail(TestContext context, String message, HttpResponse<Buffer> response,
+                           StackTraceElement [] stacktrace) {
+    Async async = context.async();
+
+    Throwable t = new AssertionFailedError((message == null ? "" : message + ": ")
+      + response.statusCode() + " " + response.statusMessage() + " " + response.bodyAsString());
+    // t contains the stacktrace of bodyHandler but does not contain the method that
+    // called this fail method. Therefore exchange the stacktrace:
+    t.setStackTrace(stacktrace);
+    context.fail(t);
+    async.complete();
+  }
+
+  /**
+   * Fail the context if response does not have the provided status.
+   */
+  static void assertStatus(TestContext context, HttpClientResponse response, int status) {
+    if (response.statusCode() == status) {
+      return;
+    }
+    StackTraceElement [] stacktrace = new Throwable().getStackTrace();
+    // remove the element with this assertStatus method from the stacktrace
+    fail(context, "Expected status " + status + " but got",
+        response, Arrays.copyOfRange(stacktrace, 1, stacktrace.length));
+  }
+
+  static void assertStatus(TestContext context, HttpResponse<Buffer> response, int status) {
+    if (response.statusCode() == status) {
+      return;
+    }
+    StackTraceElement [] stacktrace = new Throwable().getStackTrace();
+    // remove the element with this assertStatus method from the stacktrace
+    fail(context, "Expected status " + status + " but got",
+      response, Arrays.copyOfRange(stacktrace, 1, stacktrace.length));
+  }
+
+}

--- a/src/test/java/org/folio/moduserstest/RestITSupport.java
+++ b/src/test/java/org/folio/moduserstest/RestITSupport.java
@@ -191,6 +191,16 @@ class RestITSupport {
     });
   }
 
+  static Future<HttpResponse<Buffer>> delete(String request) {
+    Promise<HttpResponse<Buffer>> promise = Promise.promise();
+
+    client.delete(port, LOCALHOST, request)
+      .putHeader(OKAPI_HEADER_TENANT, "diku")
+      .putHeader("accept", "*/*")
+      .send(promise);
+
+    return promise.future();
+  }
 
   static Future<Void> deleteWithNoContentStatus(TestContext context, String request) {
     Promise<HttpResponse<Buffer>> promise = Promise.promise();

--- a/src/test/java/org/folio/moduserstest/RestITSupport.java
+++ b/src/test/java/org/folio/moduserstest/RestITSupport.java
@@ -10,7 +10,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
@@ -217,8 +216,8 @@ class RestITSupport {
     });
   }
 
-  static void getByQuery(TestContext context, String requestUrl, Promise<JsonObject> promise) {
-    HttpClient client = vertx.createHttpClient();
+  static Future<JsonObject> getByQuery(TestContext context, String requestUrl) {
+    /*HttpClient client = vertx.createHttpClient();
     client.get(port, "localhost", requestUrl, res -> {
       RestITSupport.assertStatus(context, res, HTTP_OK);
       res.bodyHandler(buf -> {
@@ -234,6 +233,19 @@ class RestITSupport {
       .putHeader("content-type", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
       .putHeader("accept", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
       .exceptionHandler(promise::fail)
-      .end();
+      .end();*/
+
+    Promise<HttpResponse<Buffer>> promise = Promise.promise();
+
+    client.get(port, LOCALHOST, requestUrl)
+      .putHeader(OKAPI_HEADER_TENANT, "diku")
+      .putHeader("content-type", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
+      .putHeader("accept", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
+      .send(promise);
+
+    return promise.future().map(res -> {
+      RestITSupport.assertStatus(context, res, HTTP_OK);
+      return res.bodyAsJsonObject();
+    });
   }
 }

--- a/src/test/java/org/folio/moduserstest/RestITSupport.java
+++ b/src/test/java/org/folio/moduserstest/RestITSupport.java
@@ -3,8 +3,12 @@ package org.folio.moduserstest;
 import static java.net.HttpURLConnection.HTTP_MULT_CHOICE;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
+
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
+
+import java.util.Arrays;
+
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -17,8 +21,8 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.predicate.ResponsePredicateResult;
-import java.util.Arrays;
 import junit.framework.AssertionFailedError;
+
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.rest.tools.utils.VertxUtils;
 
@@ -125,6 +129,19 @@ class RestITSupport {
   }
 
 
+  static Future<HttpResponse<Buffer>> post(String request, String body) {
+    Promise<HttpResponse<Buffer>> promise = Promise.promise();
+
+    client.post(port, LOCALHOST, request)
+      .putHeader(OKAPI_HEADER_TENANT, "diku")
+      .putHeader("X-Okapi-Url", RestITSupport.HTTP_LOCALHOST + port)
+      .putHeader("content-type", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
+      .putHeader("accept", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
+      .sendBuffer(Buffer.buffer(body), promise);
+
+    return promise.future();
+  }
+
   static Future<Void> postWithOkStatus(String userId, String request, String body) {
     /*HttpClient client = vertx.createHttpClient();
     client.post(port, "localhost", request, res -> {
@@ -216,24 +233,7 @@ class RestITSupport {
     });
   }
 
-  static Future<JsonObject> getByQuery(TestContext context, String requestUrl) {
-    /*HttpClient client = vertx.createHttpClient();
-    client.get(port, "localhost", requestUrl, res -> {
-      RestITSupport.assertStatus(context, res, HTTP_OK);
-      res.bodyHandler(buf -> {
-        try {
-          JsonObject resultObject = buf.toJsonObject();
-          promise.complete(resultObject);
-        } catch (Exception e) {
-          promise.fail(e);
-        }
-      });
-    })
-      .putHeader(OKAPI_HEADER_TENANT, "diku")
-      .putHeader("content-type", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
-      .putHeader("accept", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
-      .exceptionHandler(promise::fail)
-      .end();*/
+  static Future<HttpResponse<Buffer>> get(String requestUrl) {
 
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
 
@@ -243,7 +243,11 @@ class RestITSupport {
       .putHeader("accept", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
       .send(promise);
 
-    return promise.future().map(res -> {
+    return promise.future();
+  }
+
+  static Future<JsonObject> getJson(TestContext context, String requestUrl) {
+    return get(requestUrl).map(res -> {
       RestITSupport.assertStatus(context, res, HTTP_OK);
       return res.bodyAsJsonObject();
     });

--- a/src/test/java/org/folio/moduserstest/RestITSupport.java
+++ b/src/test/java/org/folio/moduserstest/RestITSupport.java
@@ -8,6 +8,8 @@ import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -18,6 +20,7 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.predicate.ResponsePredicateResult;
@@ -128,16 +131,23 @@ class RestITSupport {
       response, Arrays.copyOfRange(stacktrace, 1, stacktrace.length));
   }
 
-
   static Future<HttpResponse<Buffer>> post(String request, String body) {
+    return post(request, body, Collections.emptyMap());
+  }
+
+  static Future<HttpResponse<Buffer>> post(String request, String body,
+                                           Map<String, String> additionalHeaders) {
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
 
-    client.post(port, LOCALHOST, request)
+    HttpRequest<Buffer> req = client.post(port, LOCALHOST, request)
       .putHeader(OKAPI_HEADER_TENANT, "diku")
       .putHeader("X-Okapi-Url", RestITSupport.HTTP_LOCALHOST + port)
       .putHeader("content-type", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
-      .putHeader("accept", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
-      .sendBuffer(Buffer.buffer(body), promise);
+      .putHeader("accept", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF);
+
+    additionalHeaders.forEach(req::putHeader);
+
+    req.sendBuffer(Buffer.buffer(body), promise);
 
     return promise.future();
   }

--- a/src/test/java/org/folio/moduserstest/RestITSupport.java
+++ b/src/test/java/org/folio/moduserstest/RestITSupport.java
@@ -143,22 +143,6 @@ class RestITSupport {
   }
 
   static Future<Void> postWithOkStatus(String userId, String request, String body) {
-    /*HttpClient client = vertx.createHttpClient();
-    client.post(port, "localhost", request, res -> {
-      if (res.statusCode() >= HTTP_OK && res.statusCode() < HTTP_MULT_CHOICE) {
-        promise.complete();
-      } else {
-        promise.fail("Got status code: " + res.statusCode());
-      }
-    })
-      .putHeader(OKAPI_HEADER_TENANT, "diku")
-      .putHeader("X-Okapi-Url", RestITSupport.HTTP_LOCALHOST + port)
-      .putHeader(OKAPI_USERID_HEADER, userId)
-      .putHeader("content-type", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
-      .putHeader("accept", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
-      .exceptionHandler(promise::fail)
-      .end(body);*/
-
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
 
     client.post(port, LOCALHOST, request)
@@ -177,21 +161,20 @@ class RestITSupport {
     return promise.future().mapEmpty();
   }
 
-  static Future<Void> putWithNoContentStatus(TestContext context, String userId, String request, String body) {
-    /*HttpClient client = vertx.createHttpClient();
-    client.put(port, "localhost", request, res -> {
-      RestITSupport.assertStatus(context, res, HTTP_NO_CONTENT);
-      promise.complete();
-    })
+  static Future<HttpResponse<Buffer>> put(String request, String body) {
+    Promise<HttpResponse<Buffer>> promise = Promise.promise();
+
+    client.put(port, LOCALHOST, request)
       .putHeader(OKAPI_HEADER_TENANT, "diku")
       .putHeader("X-Okapi-Url", RestITSupport.HTTP_LOCALHOST + port)
-      .putHeader(OKAPI_USERID_HEADER, userId)
       .putHeader("content-type", RestITSupport.SUPPORTED_CONTENT_TYPE_JSON_DEF)
       .putHeader("accept", RestITSupport.SUPPORTED_CONTENT_TYPE_TEXT_DEF)
-      .exceptionHandler(promise::fail)
-      .end(body);
-    return promise.future();*/
+      .sendBuffer(Buffer.buffer(body), promise);
 
+    return promise.future();
+  }
+
+  static Future<Void> putWithNoContentStatus(TestContext context, String userId, String request, String body) {
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
 
     client.put(port, LOCALHOST, request)
@@ -210,16 +193,6 @@ class RestITSupport {
 
 
   static Future<Void> deleteWithNoContentStatus(TestContext context, String request) {
-    /*HttpClient client = vertx.createHttpClient();
-    client.delete(port, "localhost", request, res -> {
-      RestITSupport.assertStatus(context, res, HTTP_NO_CONTENT);
-      promise.complete();
-    })
-      .putHeader(OKAPI_HEADER_TENANT, "diku")*/
-      //.putHeader("accept", "*/*")
-      /*.exceptionHandler(promise::fail)
-      .end();*/
-
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
 
     client.delete(port, LOCALHOST, request)
@@ -234,7 +207,6 @@ class RestITSupport {
   }
 
   static Future<HttpResponse<Buffer>> get(String requestUrl) {
-
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
 
     client.get(port, LOCALHOST, requestUrl)

--- a/src/test/java/org/folio/moduserstest/RestVerticleIT.java
+++ b/src/test/java/org/folio/moduserstest/RestVerticleIT.java
@@ -1,11 +1,6 @@
 package org.folio.moduserstest;
 
 import static io.vertx.core.json.Json.encode;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
 import static org.folio.moduserstest.RestITSupport.assertStatus;
 import static org.folio.moduserstest.RestITSupport.delete;
 import static org.folio.moduserstest.RestITSupport.deleteWithNoContentStatus;
@@ -15,8 +10,13 @@ import static org.folio.moduserstest.RestITSupport.post;
 import static org.folio.moduserstest.RestITSupport.postWithOkStatus;
 import static org.folio.moduserstest.RestITSupport.put;
 import static org.folio.moduserstest.RestITSupport.putWithNoContentStatus;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
 import static org.folio.util.StringUtil.urlEncode;
+import static org.junit.Assert.fail;
 
+import io.vertx.ext.web.client.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -39,7 +40,6 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.ext.web.client.HttpResponse;
 import org.joda.time.DateTime;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -1129,7 +1129,7 @@ public class RestVerticleIT {
     log.info(String.format(
       "Creating object %s at endpoint %s", ob.encode(), endpoint));
 
-    HashMap<String, String> ah = new HashMap<>();
+    Map<String, String> ah = new HashMap<>();
     ah.put("X-Okapi-Token", FAKE_TOKEN);
 
     Future<String> f1 = post(endpoint, encode(ob), ah)

--- a/src/test/java/org/folio/moduserstest/RestVerticleIT.java
+++ b/src/test/java/org/folio/moduserstest/RestVerticleIT.java
@@ -276,9 +276,7 @@ public class RestVerticleIT {
 
   private Future<Void> deleteUser(TestContext context, String userId) {
     log.info("Deleting existing user\n");
-    Promise<Void> promise = Promise.promise();
-    deleteWithNoContentStatus(context, promise, "/users/" + userId);
-    return promise.future();
+    return deleteWithNoContentStatus(context, "/users/" + userId);
   }
 
   private Future<Void> postUserWithNumericName(TestContext context) {

--- a/src/test/java/org/folio/moduserstest/RestVerticleIT.java
+++ b/src/test/java/org/folio/moduserstest/RestVerticleIT.java
@@ -63,7 +63,6 @@ public class RestVerticleIT {
   private static final String joeBlockId = "ba6baf95-bf14-4020-b44c-0cad269fb5c9";
   private static final String bobCircleId = "54afd8b8-fb3b-4de8-9b7c-299904887f7d";
   private static final String jackTriangleId = "e133841d-b645-4488-9e52-9762d560b617";
-  private static final String johnRectangleId = "ae6d1c57-3041-4645-9215-3ca0094b77fc";
   private static final String annaRhombusId = "e8090974-8876-4411-befa-8ddcffad0b35";
   private static final String user777777Id = "72bd29f7-bf29-48bb-8259-d5ce78378a56";
   private static final String userIdWithWhitespace = "56bd29f7-bf29-48bb-8259-d5ce76378a42";
@@ -81,7 +80,7 @@ public class RestVerticleIT {
     .put("proxyUserId", UUID.randomUUID().toString())
     .put("status", "Active")
     .put("expirationDate",
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS\'Z\'").format(new Date()))
+      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(new Date()))
     .put("requestForSponsor", "Yes")
     .put("notificationsTo", "Proxy")
     .put("accrueTo", "Sponsor");

--- a/src/test/java/org/folio/rest/impl/ProxiesForAPITest.java
+++ b/src/test/java/org/folio/rest/impl/ProxiesForAPITest.java
@@ -1,0 +1,28 @@
+package org.folio.rest.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.folio.rest.jaxrs.model.ProxiesFor;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.interfaces.Results;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+public class ProxiesForAPITest {
+  @Test
+  void userAndProxyUserComboExistsCanHandlePostgresClientFailure() {
+    PostgresClient postgresClient = mock(PostgresClient.class);
+    Future<Boolean> future = new ProxiesForAPI()
+        .userAndProxyUserComboExists("someUserId", "someProxyUserId", postgresClient);
+    ArgumentCaptor<Handler<AsyncResult<Results<ProxiesFor>>>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
+    verify(postgresClient).get(anyString(), any(), any(Criterion.class), anyBoolean(), handlerCaptor.capture());
+    handlerCaptor.getValue().handle(Future.failedFuture(new RuntimeException("my exception")));
+    assertThat(future.cause().getMessage(), is("my exception"));
+  }
+}

--- a/src/test/java/org/folio/rest/impl/UsersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPITest.java
@@ -1,0 +1,85 @@
+package org.folio.rest.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.folio.rest.jaxrs.model.Address;
+import org.folio.rest.jaxrs.model.AddressType;
+import org.folio.rest.jaxrs.model.Personal;
+import org.folio.rest.jaxrs.model.User;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.interfaces.Results;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class UsersAPITest {
+  private void checkAddressTypeValid(VertxTestContext context,
+      AsyncResult<Results<AddressType>> result, Handler<Throwable> handler) {
+
+    PostgresClient postgresClient = mock(PostgresClient.class);
+    Future<Boolean> future = new UsersAPI()
+        .checkAddressTypeValid("someAddressTypeId", Vertx.vertx().getOrCreateContext(), postgresClient);
+    ArgumentCaptor<Handler<AsyncResult<Results<AddressType>>>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
+    verify(postgresClient, timeout(100)).get(anyString(), any(), any(Criterion.class), anyBoolean(), handlerCaptor.capture());
+    handlerCaptor.getValue().handle(result);
+    future.onComplete(context.failing(e -> context.verify(() -> {
+      handler.handle(future.cause());
+    })));
+  }
+
+  @Test
+  void checkAddressTypeValidCanHandlePostgresClientFailure(VertxTestContext context) {
+    checkAddressTypeValid(context, Future.failedFuture(new RuntimeException("postgres failed")), throwable -> {
+      assertThat(throwable.getMessage(), is("postgres failed"));
+      context.completeNow();
+    });
+  }
+
+  @Test
+  void checkAddressTypeValidCanHandleException(VertxTestContext context) {
+    checkAddressTypeValid(context, null, throwable -> {
+      assertThat(throwable, is(instanceOf(NullPointerException.class)));
+      context.completeNow();
+    });
+  }
+
+  @Test
+  void checkAddressTypeValidCanHandleNullPostgresClient(Vertx vertx, VertxTestContext context) {
+    Future<Boolean> future = new UsersAPI().checkAddressTypeValid("myId", vertx.getOrCreateContext(),
+        /* postgresClient */ null);
+    future.onComplete(context.failing(e -> context.verify(() -> {
+      assertThat(future.cause(), is(instanceOf(NullPointerException.class)));
+      context.completeNow();
+    })));
+  }
+
+  @Test
+  void checkAllAddressTypesValidCanHandleNullPostgresClient(Vertx vertx, VertxTestContext context) {
+    Address address = new Address().withAddressTypeId("someAddressTypeId");
+    Personal personal = new Personal().withAddresses(Collections.singletonList(address));
+    User user = new User().withPersonal(personal);
+    Future<Boolean> future = new UsersAPI().checkAllAddressTypesValid(user, vertx.getOrCreateContext(),
+        /* postgresClient */ null);
+    future.onComplete(context.failing(e -> context.verify(() -> {
+      assertThat(future.cause(), is(instanceOf(NullPointerException.class)));
+      context.completeNow();
+    })));
+  }
+}
+

--- a/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
+++ b/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
@@ -1,0 +1,102 @@
+package org.folio.rest.utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.folio.rest.jaxrs.model.User;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.rest.persist.interfaces.Results;
+import org.folio.rest.testing.UtilityClassTester;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.ext.sql.UpdateResult;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+public class ExpirationToolTest {
+  @AfterEach
+  void cleanup() {
+    ExpirationTool.postgresClient = PostgresClient::getInstance;
+  }
+
+  @Test
+  void isUtilityClass() {
+    UtilityClassTester.assertUtilityClass(ExpirationTool.class);
+  }
+
+  @Test
+  void expirationForNullTenant(Vertx vertx, VertxTestContext context) {
+    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, vertx.getOrCreateContext(), null);
+    future.onComplete(context.failing(e -> context.verify(() -> {
+      assertThat(future.cause(), is(instanceOf(NullPointerException.class)));
+      context.completeNow();
+    })));
+  }
+
+  @Test
+  void expirationForTenantCanHandlePostgresClientFailure(Vertx vertx, VertxTestContext context) {
+    PostgresClient postgresClient = mock(PostgresClient.class);
+    doThrow(new RuntimeException("pg"))
+      .when(postgresClient).get(anyString(), any(Class.class), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), any());
+    ExpirationTool.postgresClient = (v,t) -> postgresClient;
+    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, vertx.getOrCreateContext(), "someTenant");
+    future.onComplete(context.failing(e -> context.verify(() -> {
+      assertThat(future.cause().getMessage(), is("pg"));
+      context.completeNow();
+    })));
+  }
+
+  @Test
+  void noUsersHaveExpired(Vertx vertx, VertxTestContext context) {
+    PostgresClient postgresClient = mock(PostgresClient.class);
+    ExpirationTool.postgresClient = (v,t) -> postgresClient;
+    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, vertx.getOrCreateContext(), "someTenant");
+    ArgumentCaptor<Handler<AsyncResult<Results<User>>>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
+    verify(postgresClient)
+      .get(anyString(), any(), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), handlerCaptor.capture());
+    Results<User> results = new Results<>();
+    results.setResults(Collections.emptyList());
+    handlerCaptor.getValue().handle(Future.succeededFuture(results));
+    future.onComplete(context.succeeding(i -> context.verify(() -> {
+      assertThat(i, is(0));
+      context.completeNow();
+    })));
+  }
+
+  @Test
+  void saveUserCanHandleNullPostgresClient(Vertx vertx) {
+    ExpirationTool.postgresClient = (v,t) -> null;
+    Future<Void> future = ExpirationTool.saveUser(vertx, "myTenant", new User());
+    assertThat(future.cause(), is(instanceOf(NullPointerException.class)));
+  }
+
+  @Test
+  void saveUserCanHandlePostgresFailure(Vertx vertx) {
+    PostgresClient postgresClient = mock(PostgresClient.class);
+    ExpirationTool.postgresClient = (v,t) -> postgresClient;
+    Future<Void> future = ExpirationTool.saveUser(vertx, "myTenant", new User());
+    ArgumentCaptor<Handler<AsyncResult<UpdateResult>>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
+    verify(postgresClient).update(anyString(), any(User.class), any(), handlerCaptor.capture());
+    handlerCaptor.getValue().handle(Future.failedFuture("out of punchcards"));
+    assertThat(future.cause().getMessage(), is("out of punchcards"));
+  }
+}


### PR DESCRIPTION
Upgrade the code of the module to make it compatible with RMB v29.x and Vertex 3.8.4

Main points:
* replaces the creation and completion of io.vertx.core.Future with Promise
* refactor the tests to substitute usage of HttpClient with WebClient 
* remove all foreign keys fields and the primary key field id from the all index sections

Additionally move part of the tests out of RestVerticleIT to group them by subjects
* user groups related tests to GroupIT
* custom fields related test to CustomFieldIT

Note: for some reason WebClient doesn't want to work with data retrieved from stream (see UsersAPI.getUsers()). Without streamin it works ok.  So I had to revert code back [(5a3af74)](https://github.com/folio-org/mod-users/pull/154/commits/5a3af74dc7f851374ffecbd79830d72c332706c6) to HttpClient usage in RestVerticleIT.getUsersByCQL()