### PR TITLE
MODUSERS-171: wrong totalRecords when streaming GET /users

### DIFF
--- a/src/test/java/org/folio/moduserstest/RestVerticleIT.java
+++ b/src/test/java/org/folio/moduserstest/RestVerticleIT.java
@@ -63,7 +63,6 @@ import org.junit.runners.MethodSorters;
 
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
-import org.folio.rest.impl.UsersAPI;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.TenantAttributes;
@@ -1933,9 +1932,6 @@ public class RestVerticleIT {
       .compose(v -> getUsersByCQL(context, "id==x", DEFAULT_LIMIT) /* empty result */)
       .compose(v -> getUsersByCQL(context, "id==\"\"", DEFAULT_LIMIT, "bobcircle", "joeblock"))
       .compose(v -> getUsersByCQL(context, jSearch, DEFAULT_LIMIT, "joeblock"))
-      .compose(v -> getUsersByCQL(context, "id==x", UsersAPI.STREAM_THRESHOLD) /* empty result */)
-      .compose(v -> getUsersByCQL(context, "id==\"\"", UsersAPI.STREAM_THRESHOLD, "bobcircle", "joeblock"))
-      .compose(v -> getUsersByCQL(context, jSearch, UsersAPI.STREAM_THRESHOLD, "joeblock"))
       .compose(v -> putUserGood(context, bobCircleId, true))
       .compose(v -> putUserBadUsername(context))
       .compose(v -> putUserWithoutIdInMetadata(context))


### PR DESCRIPTION
This reverts [MODUSERS-114](https://issues.folio.org/browse/MODUSERS-114) "GET users as a stream"

There are several issues with the streaming feature:
* [MODUSERS-169](https://issues.folio.org/browse/MODUSERS-169) "User as stream returns 200 on failure"
* [MODUSERS-171](https://issues.folio.org/browse/MODUSERS-171) "wrong totalRecords when streaming GET /users"

This block other work like [MODUSERS-164](https://issues.folio.org/browse/MODUSERS-164) "Upgrade to RMB v29.x"

Therefore the streaming code of MODUSERS-114 should be reverted so that it no longer blocks the master branch. MODUSERS-114 should be developed and code reviewed in a separate pull request on a feature branch, not on master.