### PR TITLE
MODUSERS-172 Remove related values when custom field is being deleted

### DIFF
--- a/src/main/java/org/folio/service/impl/RecordRepository.java
+++ b/src/main/java/org/folio/service/impl/RecordRepository.java
@@ -1,12 +1,18 @@
 package org.folio.service.impl;
 
+import java.util.List;
+
 import io.vertx.core.Future;
 
 import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.rest.jaxrs.model.CustomFieldStatistic;
+import org.folio.rest.jaxrs.model.User;
 
 public interface RecordRepository {
 
   Future<CustomFieldStatistic> retrieveStatisticForField(CustomField field, String tenantId);
 
+  Future<List<User>> findUsersByField(CustomField field, String tenantId);
+
+  Future<Boolean> updateUser(User user, String tenantId);
 }

--- a/src/main/java/org/folio/service/impl/RecordRepositoryImpl.java
+++ b/src/main/java/org/folio/service/impl/RecordRepositoryImpl.java
@@ -1,12 +1,21 @@
 package org.folio.service.impl;
 
+import java.util.Date;
+import java.util.List;
+
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.UpdateResult;
 
 import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.rest.jaxrs.model.CustomFieldStatistic;
+import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.interfaces.Results;
 
 public class RecordRepositoryImpl implements RecordRepository {
 
@@ -25,11 +34,34 @@ public class RecordRepositoryImpl implements RecordRepository {
 
   @Override
   public Future<CustomFieldStatistic> retrieveStatisticForField(CustomField field, String tenantId) {
-    Future<ResultSet> count = Future.future();
+    Promise<ResultSet> count = Promise.promise();
 
     pgClient(tenantId).select(String.format(SELECT_USAGE_COUNT, field.getRefId()), count);
 
-    return count.map(rs -> statistic(field, rs.getResults().get(0).getInteger(0)));
+    return count.future().map(rs -> statistic(field, rs.getResults().get(0).getInteger(0)));
+  }
+
+  @Override
+  public Future<List<User>> findUsersByField(CustomField field, String tenantId) {
+    Criterion criterion = new Criterion(
+      new Criteria().addField("'customFields'").addField("'" + field.getRefId() + "'").setOperation("IS NOT NULL"));
+
+    Promise<Results<User>> promise = Promise.promise();
+
+    pgClient(tenantId).get(USERS_TABLE, User.class, criterion, false, promise);
+
+    return promise.future().map(Results::getResults);
+  }
+
+  @Override
+  public Future<Boolean> updateUser(User user, String tenantId) {
+    user.setUpdatedDate(new Date());
+
+    Promise<UpdateResult> promise = Promise.promise();
+
+    pgClient(tenantId).update(USERS_TABLE, user, user.getId(), promise);
+
+    return promise.future().map(updateResult -> updateResult.getUpdated() == 1);
   }
 
   private CustomFieldStatistic statistic(CustomField field, Integer count) {

--- a/src/main/java/org/folio/service/impl/RecordServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RecordServiceImpl.java
@@ -2,14 +2,21 @@ package org.folio.service.impl;
 
 import static io.vertx.core.Future.succeededFuture;
 
+import java.util.List;
+
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.rest.jaxrs.model.CustomFieldStatistic;
+import org.folio.rest.jaxrs.model.User;
 import org.folio.service.RecordService;
 
 public class RecordServiceImpl implements RecordService {
+
+  private static final Logger logger = LoggerFactory.getLogger(RecordServiceImpl.class);
 
   private RecordRepository repository;
 
@@ -20,12 +27,37 @@ public class RecordServiceImpl implements RecordService {
 
   @Override
   public Future<CustomFieldStatistic> retrieveStatistic(CustomField field, String tenantId) {
+    logger.info("Retrieving custom field statistic: field = {0}", field);
+
     return repository.retrieveStatisticForField(field, tenantId);
   }
 
   @Override
   public Future<Void> deleteAllValues(CustomField field, String tenantId) {
-    return succeededFuture();
+    logger.info("Removing custom field values from user records: field = {0}", field);
+
+    Future<List<User>> related = repository.findUsersByField(field, tenantId)
+      .onSuccess(users -> logger.info("The number of users found with the given field: {0}", users.size()));
+
+    return related.compose(users -> removeCustomFieldFromUsers(users, field, tenantId));
+  }
+
+  private Future<Void> removeCustomFieldFromUsers(List<User> users, CustomField field, String tenantId) {
+    Future<Void> updated = succeededFuture();
+
+    for (User user : users) {
+      Object removedValue = user.getCustomFields().getAdditionalProperties().remove(field.getRefId());
+
+      updated = updated
+        .compose(v -> repository.updateUser(user, tenantId))
+        .map(found -> {
+          logger.debug("Field removed from user: refId = {0}, value = {1}, userName = {2}",
+            field.getRefId(), removedValue, user.getUsername());
+          return null;
+        });
+    }
+
+    return updated;
   }
 
 }

--- a/src/main/resources/vertx-default-jul-logging.properties
+++ b/src/main/resources/vertx-default-jul-logging.properties
@@ -37,3 +37,4 @@ io.vertx.ext.web.level=INFO
 io.vertx.level=INFO
 io.netty.util.internal.PlatformDependent.level=SEVERE
 #org.folio.rest.level=FINEST
+org.folio.service.level=FINE

--- a/src/test/java/org/folio/rest/impl/CustomFieldRemovalTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldRemovalTest.java
@@ -1,0 +1,178 @@
+package org.folio.rest.impl;
+
+import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import static org.folio.test.util.TestUtil.mockGetWithBody;
+import static org.folio.test.util.TestUtil.readFile;
+import static org.folio.test.util.TestUtil.toJson;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import io.restassured.http.Header;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomFieldCollection;
+import org.folio.rest.jaxrs.model.CustomFields;
+import org.folio.rest.jaxrs.model.User;
+import org.folio.test.util.TestBase;
+
+@RunWith(VertxUnitRunner.class)
+public class CustomFieldRemovalTest extends TestBase {
+
+  private static final String FAKE_FIELD_ID = "11111111-1111-1111-a111-111111111111";
+
+  private static final Header USER8 = new Header(XOkapiHeaders.USER_ID, "88888888-8888-4888-8888-888888888888");
+
+  private static final String USERS_PATH = "users";
+  private static final String CUSTOM_FIELDS_PATH = "custom-fields";
+
+  private User user8;
+  private CustomField textField;
+
+  @Before
+  public void setUp() throws IOException, URISyntaxException {
+    user8 = createUser("users/user8.json");
+
+    textField = createField("fields/shortTextField.json");
+  }
+
+  @After
+  public void tearDown() {
+    CustomFieldsDBTestUtil.deleteAllCustomFields(vertx);
+
+    deleteWithNoContent(USERS_PATH + "/" + user8.getId());
+  }
+
+  @Test
+  public void shouldRemoveFieldIfNotAssignedToUser() {
+    deleteWithNoContent(CUSTOM_FIELDS_PATH + "/" + textField.getId());
+
+    CustomFieldCollection cfs = getWithOk(CUSTOM_FIELDS_PATH).as(CustomFieldCollection.class);
+
+    assertThat(cfs.getCustomFields(), empty());
+    assertThat(cfs.getTotalRecords(), equalTo(0));
+  }
+
+  @Test
+  public void shouldRemoveFieldAndItsValueIfAssignedToUser() {
+    // assign a value
+    assignValue(user8, textField.getRefId(), "someValue");
+
+    // delete the field
+    deleteWithNoContent(CUSTOM_FIELDS_PATH + "/" + textField.getId());
+
+    //validate there is no field defined
+    CustomFieldCollection cfs = getWithOk(CUSTOM_FIELDS_PATH).as(CustomFieldCollection.class);
+
+    assertThat(cfs.getCustomFields(), empty());
+    assertThat(cfs.getTotalRecords(), equalTo(0));
+
+    //validate user doesn't have the field value
+    validateFieldAbsent(user8.getId(), textField.getRefId());
+  }
+
+  @Test
+  public void shouldRemoveFieldAndAllValuesIfAssignedToSeveralUsers() throws IOException, URISyntaxException {
+    User user9 = createUser("users/user9.json");
+
+    // assign a value to one user
+    assignValue(user8, textField.getRefId(), "someValue1");
+
+    // assign a value to another user
+    assignValue(user9, textField.getRefId(), "someValue2");
+
+    // delete the field
+    deleteWithNoContent(CUSTOM_FIELDS_PATH + "/" + textField.getId());
+
+    //validate there is no field defined
+    CustomFieldCollection cfs = getWithOk(CUSTOM_FIELDS_PATH).as(CustomFieldCollection.class);
+
+    assertThat(cfs.getCustomFields(), empty());
+    assertThat(cfs.getTotalRecords(), equalTo(0));
+
+    //validate user one doesn't have the field value
+    validateFieldAbsent(user8.getId(), textField.getRefId());
+
+    //validate user two doesn't have the field value
+    validateFieldAbsent(user9.getId(), textField.getRefId());
+  }
+
+  @Test
+  public void shouldRemoveTheSpecificFieldAndItsValueButNotTheOtherField() throws IOException, URISyntaxException {
+    CustomField checkbox = createField("fields/singleCheckbox.json");
+
+    // assign values
+    assignValue(user8, textField.getRefId(), "someValue1");
+    assignValue(user8, checkbox.getRefId(), Boolean.FALSE);
+
+    // delete the field
+    deleteWithNoContent(CUSTOM_FIELDS_PATH + "/" + textField.getId());
+
+    CustomFieldCollection cfs = getWithOk(CUSTOM_FIELDS_PATH).as(CustomFieldCollection.class);
+
+    //validate there is one field left
+    assertThat(cfs.getCustomFields(), hasSize(1));
+    assertThat(cfs.getCustomFields().get(0).getName(), equalTo(checkbox.getName()));
+    assertThat(cfs.getTotalRecords(), equalTo(1));
+
+    //validate one field is still assigned to user
+    user8 = getWithOk("/" + USERS_PATH + "/" + user8.getId()).as(User.class);
+    assertThat(user8.getCustomFields().getAdditionalProperties().size(), equalTo(1));
+    assertThat(user8.getCustomFields().getAdditionalProperties(), hasEntry(checkbox.getRefId(), Boolean.FALSE));
+  }
+
+  @Test
+  @SuppressWarnings("squid:S2699")
+  public void shouldFailIfFieldDoesntExist() {
+    deleteWithStatus(CUSTOM_FIELDS_PATH + "/" + FAKE_FIELD_ID, SC_NOT_FOUND);
+  }
+
+  private CustomField createField(String pathToJson) throws IOException, URISyntaxException {
+    return postWithStatus(CUSTOM_FIELDS_PATH, readFile(pathToJson), SC_CREATED, USER8)
+      .as(CustomField.class);
+  }
+
+  private User createUser(String pathToJson) throws IOException, URISyntaxException {
+    String body = readFile(pathToJson);
+
+    User user = postWithStatus(USERS_PATH, body, SC_CREATED, USER8).as(User.class);
+
+    mockGetWithBody(new EqualToPattern("/" + USERS_PATH + "/" + user.getId()), body);
+
+    return user;
+  }
+
+  private void assignValue(User user, String fieldRefId, Object value) {
+    CustomFields fields = user.getCustomFields();
+    if (fields == null) {
+      fields = new CustomFields();
+    }
+
+    fields.setAdditionalProperty(fieldRefId, value);
+
+    user.setCustomFields(fields);
+
+    putWithNoContent(USERS_PATH + "/" + user.getId(), toJson(user), USER8);
+  }
+
+  private void validateFieldAbsent(String userId, String fieldRefId) {
+    User user = getWithOk("/" + USERS_PATH + "/" + userId).as(User.class);
+    assertThat(user.getCustomFields().getAdditionalProperties(), not(hasKey(fieldRefId)));
+  }
+}

--- a/src/test/java/org/folio/rest/impl/CustomFieldStatisticsTest.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldStatisticsTest.java
@@ -30,7 +30,7 @@ import org.folio.test.util.TestBase;
 @RunWith(VertxUnitRunner.class)
 public class CustomFieldStatisticsTest extends TestBase {
 
-  private static final String STUB_FIELD_ID = "11111111-1111-1111-a111-111111111111";
+  private static final String FAKE_FIELD_ID = "11111111-1111-1111-a111-111111111111";
 
   private static final Header USER8 = new Header(XOkapiHeaders.USER_ID, "88888888-8888-4888-8888-888888888888");
 
@@ -83,8 +83,8 @@ public class CustomFieldStatisticsTest extends TestBase {
   }
 
   @Test
-  public void shouldFailIfFieldNotExist() {
-    getWithStatus(CUSTOM_FIELDS_PATH + "/" + STUB_FIELD_ID + "/stats", SC_NOT_FOUND);
+  public void shouldFailIfFieldDoesntExist() {
+    getWithStatus(CUSTOM_FIELDS_PATH + "/" + FAKE_FIELD_ID + "/stats", SC_NOT_FOUND);
   }
 
 }

--- a/src/test/resources/fields/singleCheckbox.json
+++ b/src/test/resources/fields/singleCheckbox.json
@@ -1,0 +1,12 @@
+{
+  "name": "Is student",
+  "visible": true,
+  "required": true,
+  "type": "SINGLE_CHECKBOX",
+  "entityType": "user",
+  "helpText": "Check if user is a student",
+  "order": 2,
+  "checkboxField" : {
+    "default" : true
+  }
+}

--- a/src/test/resources/users/user9.json
+++ b/src/test/resources/users/user9.json
@@ -1,0 +1,17 @@
+{
+  "username": "mockuser9",
+  "id": "99999999-9999-4999-9999-999999999999",
+  "active": true,
+  "type": "patron",
+  "meta": {
+    "creation_date": "2016-11-05T0723",
+    "last_login_date": ""
+  },
+  "personal": {
+    "lastName": "Mockerson",
+    "middleName": "M.",
+    "firstName": "Mockey",
+    "email": "mock@biglibrary.org",
+    "phone": "2125551212"
+  }
+}


### PR DESCRIPTION
According to [MODUSERS-172](https://issues.folio.org/browse/MODUSERS-172) implement cascade removal of custom field values when the custom field is removed. 
The existing `DELETE /custom-fields/<id>` operation for custom field is extended with ability to remove related values from all the records. 