### PR TITLE
[MODUSERS-180] Maintain Patron Blocks Limits Table entries: patron group deletion

### DIFF
--- a/src/main/java/org/folio/rest/impl/UserGroupAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserGroupAPI.java
@@ -1,6 +1,5 @@
 package org.folio.rest.impl;
 
-import static io.vertx.core.Future.succeededFuture;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 
 import java.util.Map;
@@ -18,6 +17,7 @@ import org.folio.rest.tools.utils.ValidationHelper;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 /**
@@ -25,12 +25,9 @@ import io.vertx.core.Handler;
  *
  */
 public class UserGroupAPI implements Groups {
-
   public static final String GROUP_TABLE = "groups";
-  public static final String GROUP_USER_JOIN_TABLE = "groups_users";
+  private static final String PATRON_GROUP_ID_FIELD = "patronGroupId";
   private static final String PATRON_BLOCK_LIMITS_TABLE = "patron_block_limits";
-  public static final String ID_FIELD_NAME = "id";
-  public static final String PATRON_GROUP_ID_FIELD = "patronGroupId";
 
   @Validate
   @Override
@@ -52,7 +49,7 @@ public class UserGroupAPI implements Groups {
     PgUtil.post(GROUP_TABLE, entity, okapiHeaders, vertxContext, PostGroupsResponse.class, post -> {
       try {
         if (post.succeeded() && isDuplicate(post.result().getEntity().toString())) {
-          asyncResultHandler.handle(succeededFuture(
+          asyncResultHandler.handle(Future.succeededFuture(
               PostGroupsResponse.respond422WithApplicationJson(
                 ValidationHelper.createValidationErrorMessage(
                   "group", entity.getGroup(), "Group exists"))));
@@ -92,7 +89,7 @@ public class UserGroupAPI implements Groups {
               DeleteGroupsByGroupIdResponse response = reply.failed()
                 ? DeleteGroupsByGroupIdResponse.respond500WithTextPlain(reply.cause().getLocalizedMessage())
                 : DeleteGroupsByGroupIdResponse.respond204();
-              asyncResultHandler.handle(succeededFuture(response));
+              asyncResultHandler.handle(Future.succeededFuture(response));
             });
           return;
         }

--- a/src/main/java/org/folio/rest/impl/UserGroupAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserGroupAPI.java
@@ -1,11 +1,11 @@
 package org.folio.rest.impl;
 
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Usergroup;
@@ -19,8 +19,8 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-
-import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 /**
  * @author shale

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -134,155 +134,6 @@ public class GroupIT {
   }
 
   @Test
-  public void deletingGroupDeletesItsPatronBlockLimits(TestContext context) throws Exception {
-    /*
-      create a new patron group
-     */
-    final String newGroupId = "1de95200-72e4-4967-bdf8-257fb7559888";
-
-    JsonObject group = new JsonObject()
-      .put("id", newGroupId)
-      .put("group", "test_group")
-      .put("desc", "group description");
-
-    Response createGroupResponse =
-      send(groupUrl, POST, group.encode(), HTTPResponseHandlers.json()).get(5, SECONDS);
-    context.assertEquals(createGroupResponse.code, HTTP_CREATED);
-
-    /*
-      create 3 patron block limits: 2 for the newly created group, 1 for a different group
-     */
-    checkExistingLimitsByIds(context);
-
-    String limitId1 = "1de95200-72e4-4967-bdf8-000000000001";
-    String limitId2 = "1de95200-72e4-4967-bdf8-000000000002";
-    String limitId3 = "1de95200-72e4-4967-bdf8-000000000003";
-
-    String limitForNewGroup1 = new JsonObject()
-      .put("id", limitId1)
-      .put("patronGroupId", newGroupId)
-      .put("conditionId", "3d7c52dc-c732-4223-8bf8-e5917801386f")
-      .put("value", 10)
-      .encodePrettily();
-
-    String limitForNewGroup2 = new JsonObject()
-      .put("id", limitId2)
-      .put("patronGroupId", newGroupId)
-      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
-      .put("value", 11)
-      .encodePrettily();
-
-    String limitForAnotherGroup = new JsonObject()
-      .put("id", limitId3)
-      .put("patronGroupId", "503a81cd-6c26-400f-b620-14c08943697c")
-      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
-      .put("value", 12)
-      .encodePrettily();
-
-    CompletableFuture.completedFuture(null)
-      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup1, HTTPResponseHandlers.json()))
-      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup2, HTTPResponseHandlers.json()))
-      .thenComposeAsync(r -> send(limitsUrl, POST, limitForAnotherGroup, HTTPResponseHandlers.json()))
-      .get(5, SECONDS);
-
-    checkExistingLimitsByIds(context, limitId1, limitId2, limitId3);
-
-     /*
-      delete the new group, make sure its limits are gone too
-     */
-    String deleteGroupUrl = groupUrl + "/" + newGroupId;
-    Response deleteGroupResponse =
-      send(deleteGroupUrl, DELETE, null, HTTPResponseHandlers.empty()).get(5, SECONDS);
-    context.assertEquals(deleteGroupResponse.code, HTTP_NO_CONTENT);
-
-    checkExistingLimitsByIds(context, limitId3);
-  }
-
-  @Test
-  public void test3CrossTableQueries(TestContext context) throws Exception {
-    CompletableFuture<Response> postGroupCF = send(groupUrl, POST, barGroupData, HTTPResponseHandlers.json());
-    Response postGroupResponse = postGroupCF.get(5, SECONDS);
-    context.assertEquals(postGroupResponse.code, HTTP_CREATED);
-    String barGroupId = postGroupResponse.body.getString("id");
-    context.assertNotNull(barGroupId);
-
-    int inc = 0;
-    CompletableFuture<Response> addUserCF = send(userUrl, POST, createUser(null, "jhandley" + inc++, barGroupId).encode(),
-      HTTPResponseHandlers.json());
-    Response addUserResponse = addUserCF.get(5, SECONDS);
-    context.assertEquals(addUserResponse.code, HTTP_CREATED);
-    log.info(addUserResponse.body
-      + "\nStatus - " + addUserResponse.code + " at " + System.currentTimeMillis() + " for " + userUrl);
-
-    CompletableFuture<Response> addUserCF2 = send(userUrl, POST, createUser(null, "jhandley" + inc++, barGroupId).encode(),
-      HTTPResponseHandlers.json());
-    Response addUserResponse2 = addUserCF2.get(5, SECONDS);
-    context.assertEquals(addUserResponse2.code, HTTP_CREATED);
-    log.info(addUserResponse2.body
-      + "\nStatus - " + addUserResponse2.code + " at " + System.currentTimeMillis() + " for " + userUrl);
-
-    String url = HTTP_LOCALHOST + RestITSupport.port() + "/users?query=";
-
-    //query on users and sort by groups
-    String url0 = userUrl;
-    String url1 = url + urlEncode("cql.allRecords=1 sortBy patronGroup.group/sort.descending");
-    //String url1 = userUrl;
-    String url2 = url + urlEncode("cql.allrecords=1 sortBy patronGroup.group/sort.ascending");
-    //query and sort on groups via users endpoint
-    String url3 = url + urlEncode("patronGroup.group=lib* sortBy patronGroup.group/sort.descending");
-    //query on users sort on users and groups
-    String url4 = url + urlEncode("cql.allrecords=1 sortby patronGroup.group personal.lastName personal.firstName");
-    //query on users and groups sort by groups
-    String url5 = url + urlEncode("username=jhandley2nd and patronGroup.group=lib* sortby patronGroup.group");
-    //query on users and sort by users
-    String url6 = url + urlEncode("active=true sortBy username", "UTF-8");
-    //non existant group - should be 0 results
-    String url7 = url + urlEncode("username=jhandley2nd and patronGroup.group=abc* sortby patronGroup.group");
-
-    String[] urls = new String[]{url0, url1, url2, url3, url4, url5, url6, url7};
-
-    for (int i = 0; i < 8; i++) {
-      String cqlURL = urls[i];
-      CompletableFuture<Response> cf = send(cqlURL, GET, null, HTTPResponseHandlers.json());
-
-      Response cqlResponse = cf.get(5, SECONDS);
-      context.assertEquals(cqlResponse.code, HTTP_OK);
-      log.info(cqlResponse.body
-        + "\nStatus - " + cqlResponse.code + " at " + System.currentTimeMillis() + " for " + cqlURL + " (url" + (i) + ") : " + cqlResponse.body.toString());
-      //requests should usually have 3 or 4 results
-      switch (i) {
-        case 5:
-          context.assertEquals(1, cqlResponse.body.getInteger("totalRecords"));
-          break;
-        case 7:
-          context.assertEquals(0, cqlResponse.body.getInteger("totalRecords"));
-          break;
-        case 6:
-          context.assertTrue(cqlResponse.body.getInteger("totalRecords") > 2);
-          break;
-        case 1:
-          context.assertTrue(cqlResponse.body.getInteger("totalRecords") > 1);
-          context.assertEquals("jhandley2nd", cqlResponse.body.getJsonArray("users").getJsonObject(0).getString("username"));
-          break;
-        case 2:
-          context.assertNotEquals("jhandley2nd", cqlResponse.body.getJsonArray("users").getJsonObject(0).getString("username"));
-          break;
-        case 4:
-          context.assertTrue(((String) (new JsonPathParser(cqlResponse.body).getValueAt("users[0].personal.lastName"))).startsWith("Triangle"));
-          break;
-        case 0:
-          //Baseline test
-          int totalRecords = cqlResponse.body.getInteger("totalRecords");
-          context.assertTrue(totalRecords > 3, "totalRecords = " + totalRecords + " > 3");
-          break;
-        default:
-          context.assertInRange(2, cqlResponse.body.getInteger("totalRecords"), 2);
-          break;
-      }
-    }
-  }
-
-  @Test
   public void test2Group(TestContext context) throws Exception {
     /*
       add a group
@@ -606,6 +457,71 @@ public class GroupIT {
           break;
       }
     }
+  }
+
+  @Test
+  public void deletingGroupDeletesItsPatronBlockLimits(TestContext context) throws Exception {
+    /*
+      create a new patron group
+     */
+    final String newGroupId = "1de95200-72e4-4967-bdf8-257fb7559888";
+
+    JsonObject group = new JsonObject()
+      .put("id", newGroupId)
+      .put("group", "test_group")
+      .put("desc", "group description");
+
+    Response createGroupResponse =
+      send(groupUrl, POST, group.encode(), HTTPResponseHandlers.json()).get(5, SECONDS);
+    context.assertEquals(createGroupResponse.code, HTTP_CREATED);
+
+    /*
+      create 3 patron block limits: 2 for the newly created group, 1 for a different group
+     */
+    checkExistingLimitsByIds(context);
+
+    String limitId1 = "1de95200-72e4-4967-bdf8-000000000001";
+    String limitId2 = "1de95200-72e4-4967-bdf8-000000000002";
+    String limitId3 = "1de95200-72e4-4967-bdf8-000000000003";
+
+    String limitForNewGroup1 = new JsonObject()
+      .put("id", limitId1)
+      .put("patronGroupId", newGroupId)
+      .put("conditionId", "3d7c52dc-c732-4223-8bf8-e5917801386f")
+      .put("value", 10)
+      .encodePrettily();
+
+    String limitForNewGroup2 = new JsonObject()
+      .put("id", limitId2)
+      .put("patronGroupId", newGroupId)
+      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
+      .put("value", 11)
+      .encodePrettily();
+
+    String limitForAnotherGroup = new JsonObject()
+      .put("id", limitId3)
+      .put("patronGroupId", "503a81cd-6c26-400f-b620-14c08943697c")
+      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
+      .put("value", 12)
+      .encodePrettily();
+
+    CompletableFuture.completedFuture(null)
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup1, HTTPResponseHandlers.json()))
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup2, HTTPResponseHandlers.json()))
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForAnotherGroup, HTTPResponseHandlers.json()))
+      .get(5, SECONDS);
+
+    checkExistingLimitsByIds(context, limitId1, limitId2, limitId3);
+
+     /*
+      delete the new group, make sure its limits are gone too
+     */
+    String deleteGroupUrl = groupUrl + "/" + newGroupId;
+    Response deleteGroupResponse =
+      send(deleteGroupUrl, DELETE, null, HTTPResponseHandlers.empty()).get(5, SECONDS);
+    context.assertEquals(deleteGroupResponse.code, HTTP_NO_CONTENT);
+
+    checkExistingLimitsByIds(context, limitId3);
   }
 
   private CompletableFuture<Response> send(String url, HttpMethod method, String content,

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -133,6 +133,71 @@ public class GroupIT {
   }
 
   @Test
+  public void deletingGroupDeletesItsPatronBlockLimits(TestContext context) throws Exception {
+    /*
+      create a new patron group
+     */
+    final String newGroupId = "1de95200-72e4-4967-bdf8-257fb7559888";
+
+    JsonObject group = new JsonObject()
+      .put("id", newGroupId)
+      .put("group", "test_group")
+      .put("desc", "group description");
+
+    Response createGroupResponse =
+      send(groupUrl, POST, group.encode(), HTTPResponseHandlers.json()).get(5, SECONDS);
+    context.assertEquals(createGroupResponse.code, HTTP_CREATED);
+
+    /*
+      create 3 patron block limits: 2 for the newly created group, 1 for a different group
+     */
+    checkExistingLimitsByIds(context);
+
+    String limitId1 = "1de95200-72e4-4967-bdf8-000000000001";
+    String limitId2 = "1de95200-72e4-4967-bdf8-000000000002";
+    String limitId3 = "1de95200-72e4-4967-bdf8-000000000003";
+
+    String limitForNewGroup1 = new JsonObject()
+      .put("id", limitId1)
+      .put("patronGroupId", newGroupId)
+      .put("conditionId", "3d7c52dc-c732-4223-8bf8-e5917801386f")
+      .put("value", 10)
+      .encodePrettily();
+
+    String limitForNewGroup2 = new JsonObject()
+      .put("id", limitId2)
+      .put("patronGroupId", newGroupId)
+      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
+      .put("value", 11)
+      .encodePrettily();
+
+    String limitForAnotherGroup = new JsonObject()
+      .put("id", limitId3)
+      .put("patronGroupId", "503a81cd-6c26-400f-b620-14c08943697c")
+      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
+      .put("value", 12)
+      .encodePrettily();
+
+    CompletableFuture.completedFuture(null)
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup1, HTTPResponseHandlers.json()))
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup2, HTTPResponseHandlers.json()))
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForAnotherGroup, HTTPResponseHandlers.json()))
+      .get(5, SECONDS);
+
+    checkExistingLimitsByIds(context, limitId1, limitId2, limitId3);
+
+     /*
+      delete the new group, make sure its limits are gone too
+     */
+    String deleteGroupUrl = groupUrl + "/" + newGroupId;
+    Response deleteGroupResponse =
+      send(deleteGroupUrl, DELETE, null, HTTPResponseHandlers.empty()).get(5, SECONDS);
+    context.assertEquals(deleteGroupResponse.code, HTTP_NO_CONTENT);
+
+    checkExistingLimitsByIds(context, limitId3);
+  }
+
+  @Test
   public void test3CrossTableQueries(TestContext context) throws Exception {
     CompletableFuture<Response> postGroupCF = send(groupUrl, POST, barGroupData, HTTPResponseHandlers.json());
     Response postGroupResponse = postGroupCF.get(5, SECONDS);
@@ -458,71 +523,6 @@ public class GroupIT {
       Response getExpiredUserResponse = getExpiredUserCF.get(5, SECONDS);
       context.assertEquals(getExpiredUserResponse.body.getBoolean("active"), false);
     }
-  }
-
-  @Test
-  public void deletingGroupDeletesItsPatronBlockLimits(TestContext context) throws Exception {
-    /*
-      create a new patron group
-     */
-    final String newGroupId = "1de95200-72e4-4967-bdf8-257fb7559888";
-
-    JsonObject group = new JsonObject()
-      .put("id", newGroupId)
-      .put("group", "test_group")
-      .put("desc", "group description");
-
-    Response createGroupResponse =
-      send(groupUrl, POST, group.encode(), HTTPResponseHandlers.json()).get(5, SECONDS);
-    context.assertEquals(createGroupResponse.code, HTTP_CREATED);
-
-    /*
-      create 3 patron block limits: 2 for the newly created group, 1 for a different group
-     */
-    checkExistingLimitsByIds(context);
-
-    String limitId1 = "1de95200-72e4-4967-bdf8-000000000001";
-    String limitId2 = "1de95200-72e4-4967-bdf8-000000000002";
-    String limitId3 = "1de95200-72e4-4967-bdf8-000000000003";
-
-    String limitForNewGroup1 = new JsonObject()
-      .put("id", limitId1)
-      .put("patronGroupId", newGroupId)
-      .put("conditionId", "3d7c52dc-c732-4223-8bf8-e5917801386f")
-      .put("value", 10)
-      .encodePrettily();
-
-    String limitForNewGroup2 = new JsonObject()
-      .put("id", limitId2)
-      .put("patronGroupId", newGroupId)
-      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
-      .put("value", 11)
-      .encodePrettily();
-
-    String limitForAnotherGroup = new JsonObject()
-      .put("id", limitId3)
-      .put("patronGroupId", "503a81cd-6c26-400f-b620-14c08943697c")
-      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
-      .put("value", 12)
-      .encodePrettily();
-
-    CompletableFuture.completedFuture(null)
-      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup1, HTTPResponseHandlers.json()))
-      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup2, HTTPResponseHandlers.json()))
-      .thenComposeAsync(r -> send(limitsUrl, POST, limitForAnotherGroup, HTTPResponseHandlers.json()))
-      .get(5, SECONDS);
-
-    checkExistingLimitsByIds(context, limitId1, limitId2, limitId3);
-
-     /*
-      delete the new group, make sure its limits are gone too
-     */
-    String deleteGroupUrl = groupUrl + "/" + newGroupId;
-    Response deleteGroupResponse =
-      send(deleteGroupUrl, DELETE, null, HTTPResponseHandlers.empty()).get(5, SECONDS);
-    context.assertEquals(deleteGroupResponse.code, HTTP_NO_CONTENT);
-
-    checkExistingLimitsByIds(context, limitId3);
   }
 
   private CompletableFuture<Response> send(String url, HttpMethod method, String content,

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -21,12 +21,18 @@ import static org.folio.moduserstest.RestITSupport.put;
 import static org.folio.util.StringUtil.urlEncode;
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
@@ -66,6 +72,7 @@ public class GroupIT {
 
   private static final String fooGroupData = "{\"group\": \"librarianFOO\",\"desc\": \"yet another basic lib group\"}";
   private static final String barGroupData = "{\"group\": \"librarianBAR\",\"desc\": \"and yet another basic lib group\"}";
+  private static final String limitsUrl = "/patron-block-limits";
 
   private static final Logger log = LoggerFactory.getLogger(GroupIT.class);
 
@@ -73,7 +80,6 @@ public class GroupIT {
 
   @Rule
   public Timeout rule = Timeout.seconds(20);
-
 
   @BeforeClass
   public static void setup(TestContext context) {
@@ -124,6 +130,71 @@ public class GroupIT {
       future.complete(null);
     });
     future.join();
+  }
+
+  @Test
+  public void deletingGroupDeletesItsPatronBlockLimits(TestContext context) throws Exception {
+    /*
+      create a new patron group
+     */
+    final String newGroupId = "1de95200-72e4-4967-bdf8-257fb7559888";
+
+    JsonObject group = new JsonObject()
+      .put("id", newGroupId)
+      .put("group", "test_group")
+      .put("desc", "group description");
+
+    Response createGroupResponse =
+      send(groupUrl, POST, group.encode(), HTTPResponseHandlers.json()).get(5, SECONDS);
+    context.assertEquals(createGroupResponse.code, HTTP_CREATED);
+
+    /*
+      create 3 patron block limits: 2 for the newly created group, 1 for a different group
+     */
+    checkExistingLimitsByIds(context);
+
+    String limitId1 = "1de95200-72e4-4967-bdf8-000000000001";
+    String limitId2 = "1de95200-72e4-4967-bdf8-000000000002";
+    String limitId3 = "1de95200-72e4-4967-bdf8-000000000003";
+
+    String limitForNewGroup1 = new JsonObject()
+      .put("id", limitId1)
+      .put("patronGroupId", newGroupId)
+      .put("conditionId", "3d7c52dc-c732-4223-8bf8-e5917801386f")
+      .put("value", 10)
+      .encodePrettily();
+
+    String limitForNewGroup2 = new JsonObject()
+      .put("id", limitId2)
+      .put("patronGroupId", newGroupId)
+      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
+      .put("value", 11)
+      .encodePrettily();
+
+    String limitForAnotherGroup = new JsonObject()
+      .put("id", limitId3)
+      .put("patronGroupId", "503a81cd-6c26-400f-b620-14c08943697c")
+      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
+      .put("value", 12)
+      .encodePrettily();
+
+    CompletableFuture.completedFuture(null)
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup1, HTTPResponseHandlers.json()))
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup2, HTTPResponseHandlers.json()))
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForAnotherGroup, HTTPResponseHandlers.json()))
+      .get(5, SECONDS);
+
+    checkExistingLimitsByIds(context, limitId1, limitId2, limitId3);
+
+     /*
+      delete the new group, make sure its limits are gone
+     */
+    String deleteGroupUrl = groupUrl + "/" + newGroupId;
+    Response deleteGroupResponse =
+      send(deleteGroupUrl, DELETE, null, HTTPResponseHandlers.empty()).get(5, SECONDS);
+    context.assertEquals(deleteGroupResponse.code, HTTP_NO_CONTENT);
+
+    checkExistingLimitsByIds(context, limitId3);
   }
 
   @Test
@@ -511,6 +582,25 @@ public class GroupIT {
 
     int code;
     JsonObject body;
+  }
+
+  private void checkExistingLimitsByIds(TestContext context, String... expectedIds)
+    throws InterruptedException, ExecutionException, TimeoutException {
+
+    Response response = send(limitsUrl, GET, null, HTTPResponseHandlers.json())
+      .get(5, SECONDS);
+    context.assertEquals(response.code, HTTP_OK);
+
+    Set<String> actualLimitIds = response.body
+      .getJsonArray("patronBlockLimits")
+      .stream()
+      .map(JsonObject.class::cast)
+      .map(limit -> limit.getString("id"))
+      .collect(Collectors.toSet());
+
+    Set<String> expectedLimitIds = new HashSet<>(Arrays.asList(expectedIds));
+
+    context.assertEquals(expectedLimitIds, actualLimitIds);
   }
 
   private static class HTTPResponseHandlers {

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -133,71 +133,6 @@ public class GroupIT {
   }
 
   @Test
-  public void deletingGroupDeletesItsPatronBlockLimits(TestContext context) throws Exception {
-    /*
-      create a new patron group
-     */
-    final String newGroupId = "1de95200-72e4-4967-bdf8-257fb7559888";
-
-    JsonObject group = new JsonObject()
-      .put("id", newGroupId)
-      .put("group", "test_group")
-      .put("desc", "group description");
-
-    Response createGroupResponse =
-      send(groupUrl, POST, group.encode(), HTTPResponseHandlers.json()).get(5, SECONDS);
-    context.assertEquals(createGroupResponse.code, HTTP_CREATED);
-
-    /*
-      create 3 patron block limits: 2 for the newly created group, 1 for a different group
-     */
-    checkExistingLimitsByIds(context);
-
-    String limitId1 = "1de95200-72e4-4967-bdf8-000000000001";
-    String limitId2 = "1de95200-72e4-4967-bdf8-000000000002";
-    String limitId3 = "1de95200-72e4-4967-bdf8-000000000003";
-
-    String limitForNewGroup1 = new JsonObject()
-      .put("id", limitId1)
-      .put("patronGroupId", newGroupId)
-      .put("conditionId", "3d7c52dc-c732-4223-8bf8-e5917801386f")
-      .put("value", 10)
-      .encodePrettily();
-
-    String limitForNewGroup2 = new JsonObject()
-      .put("id", limitId2)
-      .put("patronGroupId", newGroupId)
-      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
-      .put("value", 11)
-      .encodePrettily();
-
-    String limitForAnotherGroup = new JsonObject()
-      .put("id", limitId3)
-      .put("patronGroupId", "503a81cd-6c26-400f-b620-14c08943697c")
-      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
-      .put("value", 12)
-      .encodePrettily();
-
-    CompletableFuture.completedFuture(null)
-      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup1, HTTPResponseHandlers.json()))
-      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup2, HTTPResponseHandlers.json()))
-      .thenComposeAsync(r -> send(limitsUrl, POST, limitForAnotherGroup, HTTPResponseHandlers.json()))
-      .get(5, SECONDS);
-
-    checkExistingLimitsByIds(context, limitId1, limitId2, limitId3);
-
-     /*
-      delete the new group, make sure its limits are gone
-     */
-    String deleteGroupUrl = groupUrl + "/" + newGroupId;
-    Response deleteGroupResponse =
-      send(deleteGroupUrl, DELETE, null, HTTPResponseHandlers.empty()).get(5, SECONDS);
-    context.assertEquals(deleteGroupResponse.code, HTTP_NO_CONTENT);
-
-    checkExistingLimitsByIds(context, limitId3);
-  }
-
-  @Test
   public void test3CrossTableQueries(TestContext context) throws Exception {
     CompletableFuture<Response> postGroupCF = send(groupUrl, POST, barGroupData, HTTPResponseHandlers.json());
     Response postGroupResponse = postGroupCF.get(5, SECONDS);
@@ -523,6 +458,71 @@ public class GroupIT {
       Response getExpiredUserResponse = getExpiredUserCF.get(5, SECONDS);
       context.assertEquals(getExpiredUserResponse.body.getBoolean("active"), false);
     }
+  }
+
+  @Test
+  public void deletingGroupDeletesItsPatronBlockLimits(TestContext context) throws Exception {
+    /*
+      create a new patron group
+     */
+    final String newGroupId = "1de95200-72e4-4967-bdf8-257fb7559888";
+
+    JsonObject group = new JsonObject()
+      .put("id", newGroupId)
+      .put("group", "test_group")
+      .put("desc", "group description");
+
+    Response createGroupResponse =
+      send(groupUrl, POST, group.encode(), HTTPResponseHandlers.json()).get(5, SECONDS);
+    context.assertEquals(createGroupResponse.code, HTTP_CREATED);
+
+    /*
+      create 3 patron block limits: 2 for the newly created group, 1 for a different group
+     */
+    checkExistingLimitsByIds(context);
+
+    String limitId1 = "1de95200-72e4-4967-bdf8-000000000001";
+    String limitId2 = "1de95200-72e4-4967-bdf8-000000000002";
+    String limitId3 = "1de95200-72e4-4967-bdf8-000000000003";
+
+    String limitForNewGroup1 = new JsonObject()
+      .put("id", limitId1)
+      .put("patronGroupId", newGroupId)
+      .put("conditionId", "3d7c52dc-c732-4223-8bf8-e5917801386f")
+      .put("value", 10)
+      .encodePrettily();
+
+    String limitForNewGroup2 = new JsonObject()
+      .put("id", limitId2)
+      .put("patronGroupId", newGroupId)
+      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
+      .put("value", 11)
+      .encodePrettily();
+
+    String limitForAnotherGroup = new JsonObject()
+      .put("id", limitId3)
+      .put("patronGroupId", "503a81cd-6c26-400f-b620-14c08943697c")
+      .put("conditionId", "72b67965-5b73-4840-bc0b-be8f3f6e047e")
+      .put("value", 12)
+      .encodePrettily();
+
+    CompletableFuture.completedFuture(null)
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup1, HTTPResponseHandlers.json()))
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForNewGroup2, HTTPResponseHandlers.json()))
+      .thenComposeAsync(r -> send(limitsUrl, POST, limitForAnotherGroup, HTTPResponseHandlers.json()))
+      .get(5, SECONDS);
+
+    checkExistingLimitsByIds(context, limitId1, limitId2, limitId3);
+
+     /*
+      delete the new group, make sure its limits are gone too
+     */
+    String deleteGroupUrl = groupUrl + "/" + newGroupId;
+    Response deleteGroupResponse =
+      send(deleteGroupUrl, DELETE, null, HTTPResponseHandlers.empty()).get(5, SECONDS);
+    context.assertEquals(deleteGroupResponse.code, HTTP_NO_CONTENT);
+
+    checkExistingLimitsByIds(context, limitId3);
   }
 
   private CompletableFuture<Response> send(String url, HttpMethod method, String content,


### PR DESCRIPTION
**Purpose**
When a patron group is deleted, delete all patron block limits assosiated with it.

This PR resolves [MODUSERS-180](https://issues.folio.org/browse/MODUSERS-180).