### PR TITLE
Fix ID is mandatory when POSTing a new user MODUSERS-187

### DIFF
--- a/ramls/userdata.json
+++ b/ramls/userdata.json
@@ -167,8 +167,5 @@
       "additionalProperties": true
     }
   },
-  "additionalProperties": false,
-  "required": [
-    "id"
-  ]
+  "additionalProperties": false
 }

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -489,9 +489,6 @@ public class GroupIT {
     JsonObject user = new JsonObject();
     if (id != null) {
       user.put("id", id);
-    } else {
-      id = UUID.randomUUID().toString();
-      user.put("id", id);
     }
     user.put("username", name);
     user.put("patronGroup", pgId);


### PR DESCRIPTION
Not a problem in RMB, but because, for some reason, id is required
in the JSON schema.