### PR TITLE
Change version to 17.0.0 MODUSERS-197 MODUSERS-193

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>16.2.1-SNAPSHOT</version>
+  <version>17.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>


### PR DESCRIPTION
The changes for MODUSERS-193 included removing provision of the
`patron-block-conditions` and `patron-block-limits` interfaces and MODUSERS-201 included an incompatible change to the `custom-fields` interface. 

These are considered incompatible with the last release and hence the major version should change.

