### PR TITLE
MODUSERS-221: Fix ExpirationTool nspname LIKE and error logging

### DIFF
--- a/src/main/java/org/folio/rest/utils/ExpirationTool.java
+++ b/src/main/java/org/folio/rest/utils/ExpirationTool.java
@@ -37,35 +37,35 @@ public final class ExpirationTool {
     context.runOnContext(v -> {
       //Get a list of tenants
       PostgresClient pgClient = PostgresClient.getInstance(vertx);
-      String tenantQuery = "select nspname from pg_catalog.pg_namespace where nspname LIKE '%_mod_users';";
+      String tenantQuery = "select nspname from pg_catalog.pg_namespace where nspname ~ '^[^_]+_mod_users$';";
       pgClient.select(tenantQuery, reply -> {
-        if(reply.succeeded()) {
-          RowSet<Row> rows = reply.result();
-          rows.forEach(row->{
-            String nsTenant = row.getString("nspname");
-            String suffix = "_mod_users";
-            int suffixLength = nsTenant.length() - suffix.length();
-            final String tenant = nsTenant.substring(0, suffixLength);
-            logger.info("Calling doExpirationForTenant for tenant " + tenant);
-            Future<Integer> expireFuture = doExpirationForTenant(vertx, context, tenant);
-            expireFuture.onComplete(res -> {
-              if(res.failed()) {
-                logger.info(String.format("Attempt to expire records for tenant %s failed: %s",
-                        tenant, res.cause().getLocalizedMessage()));
-              } else {
-                logger.info(String.format("Expired %s users", res.result()));
-              }
-            });
-          });
-        } else {
-          logger.info(String.format("TenantQuery '%s' failed: %s", tenantQuery,
-                  reply.cause().getLocalizedMessage()));
+        if (reply.failed()) {
+          logger.error(String.format("TenantQuery '%s' failed: %s",
+              tenantQuery, reply.cause().getMessage()), reply.cause());
+          return;
         }
+        RowSet<Row> rows = reply.result();
+        rows.forEach(row->{
+          String nsTenant = row.getString("nspname");
+          String suffix = "_mod_users";
+          int suffixLength = nsTenant.length() - suffix.length();
+          final String tenant = nsTenant.substring(0, suffixLength);
+          logger.info("Calling doExpirationForTenant for tenant " + tenant);
+          Future<Integer> expireFuture = doExpirationForTenant(vertx, tenant);
+          expireFuture.onComplete(res -> {
+            if (res.failed()) {
+              logger.error(String.format("Attempt to expire records for tenant %s failed: %s",
+                      tenant, res.cause().getMessage()), res.cause());
+            } else {
+              logger.info(String.format("Expired %s users for tenant %s", res.result(), tenant));
+            }
+          });
+        });
       });
     });
   }
 
-  public static Future<Integer> doExpirationForTenant(Vertx vertx, Context context, String tenant) {
+  public static Future<Integer> doExpirationForTenant(Vertx vertx, String tenant) {
     Promise<Integer> promise = Promise.promise();
     try {
       String nowDateString =  new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS\'Z\'").format(new Date());
@@ -76,13 +76,13 @@ public final class ExpirationTool {
       PostgresClient pgClient = postgresClient.apply(vertx, tenant);
       pgClient.get(TABLE_NAME_USERS, User.class, fieldList, cqlWrapper, true, false, reply -> {
         if (reply.failed()) {
-          logger.info(String.format("Error executing postgres query: '%s', %s",
-            query, reply.cause().getLocalizedMessage()));
+          logger.error(String.format("Error executing postgres query for tenant %s: '%s', %s",
+            tenant, query, reply.cause().getMessage()), reply.cause());
           promise.fail(reply.cause());
           return;
         }
         if (reply.result().getResults().isEmpty()) {
-          logger.info(String.format("No results found for query %s", query));
+          logger.info(String.format("No results found for tenant %s and query %s", tenant, query));
           promise.complete(0);
           return;
         }
@@ -106,13 +106,13 @@ public final class ExpirationTool {
       });
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
-      promise.fail(e);
+      promise.tryFail(e);
     }
     return promise.future();
   }
 
   static Future<Void> saveUser(Vertx vertx, String tenant, User user) {
-    logger.info(String.format("Updating user with id %s", user.getId()));
+    logger.info(String.format("Updating user with id %s for tenant %s", user.getId(), tenant));
     Promise<Void> promise = Promise.promise();
     try {
       PostgresClient pgClient = postgresClient.apply(vertx, tenant);
@@ -121,8 +121,8 @@ public final class ExpirationTool {
           promise.complete();
           return;
         }
-        logger.info(String.format("Error updating user %s: %s", user.getId(),
-          updateReply.cause().getLocalizedMessage()));
+        logger.error(String.format("Error updating user %s for tenant %s: %s", user.getId(), tenant,
+          updateReply.cause().getMessage()), updateReply.cause());
         promise.fail(updateReply.cause());
       });
     } catch(Exception e) {

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -357,7 +357,7 @@ public class GroupIT {
         + System.currentTimeMillis() + " for " + addUserURL + " (addExpiredUser)");
       context.assertEquals(addExpiredUserResponse.code, 201);
       CompletableFuture<Void> getExpirationCF = new CompletableFuture<Void>();
-      ExpirationTool.doExpirationForTenant(RestITSupport.vertx(), RestITSupport.context(), "diku")
+      ExpirationTool.doExpirationForTenant(RestITSupport.vertx(), "diku")
         .onComplete(res -> getExpirationCF.complete(null));
       getExpirationCF.get(5, SECONDS);
       //TimeUnit.SECONDS.sleep(15);

--- a/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
+++ b/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
@@ -54,7 +54,7 @@ public class ExpirationToolTest {
 
   @Test
   void expirationForNullTenant(Vertx vertx, VertxTestContext context) {
-    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, vertx.getOrCreateContext(), null);
+    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, null);
     future.onComplete(context.failing(e -> context.verify(() -> {
       assertThat(future.cause(), is(instanceOf(NullPointerException.class)));
       context.completeNow();
@@ -67,7 +67,7 @@ public class ExpirationToolTest {
     doThrow(new RuntimeException("pg"))
       .when(postgresClient).get(anyString(), any(Class.class), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), any());
     ExpirationTool.postgresClient = (v,t) -> postgresClient;
-    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, vertx.getOrCreateContext(), "someTenant");
+    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, "someTenant");
     future.onComplete(context.failing(e -> context.verify(() -> {
       assertThat(future.cause().getMessage(), is("pg"));
       context.completeNow();
@@ -78,7 +78,7 @@ public class ExpirationToolTest {
   void expirationForTenantCanHandlePostgresClientFailure(Vertx vertx, VertxTestContext context) {
     PostgresClient postgresClient = mock(PostgresClient.class);
     ExpirationTool.postgresClient = (v,t) -> postgresClient;
-    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, vertx.getOrCreateContext(), "someTenant");
+    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, "someTenant");
     ArgumentCaptor<Handler<AsyncResult<Results<User>>>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
     verify(postgresClient)
       .get(anyString(), any(), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), handlerCaptor.capture());
@@ -93,7 +93,7 @@ public class ExpirationToolTest {
   void noUsersHaveExpired(Vertx vertx, VertxTestContext context) {
     PostgresClient postgresClient = mock(PostgresClient.class);
     ExpirationTool.postgresClient = (v,t) -> postgresClient;
-    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, vertx.getOrCreateContext(), "someTenant");
+    Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, "someTenant");
     ArgumentCaptor<Handler<AsyncResult<Results<User>>>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
     verify(postgresClient)
       .get(anyString(), any(), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), handlerCaptor.capture());

--- a/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
+++ b/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
@@ -107,17 +107,17 @@ public class ExpirationToolTest {
   }
 
   @Test
-  void saveUserCanHandleNullPostgresClient(Vertx vertx) {
+  void disableUserCanHandleNullPostgresClient(Vertx vertx) {
     ExpirationTool.postgresClient = (v,t) -> null;
-    Future<Void> future = ExpirationTool.saveUser(vertx, "myTenant", new User());
+    Future<Void> future = ExpirationTool.disableUser(vertx, "myTenant", new User());
     assertThat(future.cause(), is(instanceOf(NullPointerException.class)));
   }
 
   @Test
-  void saveUserCanHandlePostgresFailure(Vertx vertx) {
+  void disableUserCanHandlePostgresFailure(Vertx vertx) {
     PostgresClient postgresClient = mock(PostgresClient.class);
     ExpirationTool.postgresClient = (v,t) -> postgresClient;
-    Future<Void> future = ExpirationTool.saveUser(vertx, "myTenant", new User());
+    Future<Void> future = ExpirationTool.disableUser(vertx, "myTenant", new User());
     ArgumentCaptor<Handler<AsyncResult<RowSet<Row>>>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
     verify(postgresClient).update(anyString(), any(User.class), any(), handlerCaptor.capture());
     handlerCaptor.getValue().handle(Future.failedFuture("out of punchcards"));


### PR DESCRIPTION
`nspname LIKE '%_mod_users'`
matches diku_my_mod_users and diku_modmusers.
This is wrong.
Use `nspname ~ '^[^_]+_mod_users$'` instead.

Errors are logged using logger.info. Use logger.error instead.

Log tenant.

Remove unused Context parameter.