### PR TITLE
MODUSERS-224: Upgrade vert.x from 3.9.2 to 3.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.2</version>
+        <version>3.9.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This may fix https://issues.folio.org/browse/MODUSERS-213 "current transaction is aborted".

Release notes: https://github.com/vert-x3/wiki/wiki/3.9.3-Release-Notes#vertx-sql-client
They mention several fixes regarding prepared statements and RowStream, most notably:

https://github.com/eclipse-vertx/vertx-sql-client/issues/730 RowStream implementation fixes:
The implementation of RowStream does not manage correctly its state (e.g it is not reentrant)
and **does not close the cursor** when it is not needed anymore.