### PR TITLE
MODUSERS-227: Sample users for SSO login using samltest.id

### DIFF
--- a/src/main/resources/sample-data/README.md
+++ b/src/main/resources/sample-data/README.md
@@ -1,0 +1,11 @@
+User300.json, User301.json and User302.json contain
+three users that https://samltest.id/ uses for its
+test IdP and that FOLIO demo/test installations can
+use for Single-Sign-On (SSO) based on
+https://github.com/folio-org/mod-login-saml
+Usernames and passwords are
+
+rick psych
+morty panic
+sheldon bazinga
+

--- a/src/main/resources/sample-data/README.md
+++ b/src/main/resources/sample-data/README.md
@@ -3,9 +3,11 @@ three users that https://samltest.id/ uses for its
 test IdP and that FOLIO demo/test installations can
 use for Single-Sign-On (SSO) based on
 https://github.com/folio-org/mod-login-saml
+
 Usernames and passwords are
 
-rick psych
-morty panic
+```
+rick    psych
+morty   panic
 sheldon bazinga
-
+```

--- a/src/main/resources/sample-data/users/User046.json
+++ b/src/main/resources/sample-data/users/User046.json
@@ -4,7 +4,7 @@
    "enrollmentDate" : "2017-04-27",
    "expirationDate" : "2019-05-09",
    "barcode" : "908122635201927",
-   "username" : "rick",
+   "username" : "rick1",
    "id" : "01b9d72b-9aab-4efd-97a4-d03c1667bf0d",
    "personal" : {
       "preferredContactTypeId" : "002",

--- a/src/main/resources/sample-data/users/User300.json
+++ b/src/main/resources/sample-data/users/User300.json
@@ -1,0 +1,17 @@
+{
+  "username": "rick",
+  "id": "2205005b-ca51-4a04-87fd-938eefa8f6de",
+  "barcode": "123",
+  "active": true,
+  "patronGroup": "3684a786-6671-4268-8ed0-9db82ebca60b",
+  "departments": [],
+  "proxyFor": [],
+  "personal": {
+    "lastName": "rick",
+    "firstName": "psych",
+    "email": "rick@example.com",
+    "addresses": [],
+    "preferredContactTypeId": "002"
+  },
+  "enrollmentDate": "2020-10-07T04:00:00.000+0000"
+}

--- a/src/main/resources/sample-data/users/User301.json
+++ b/src/main/resources/sample-data/users/User301.json
@@ -1,0 +1,17 @@
+{
+  "username": "morty",
+  "id": "bec20636-fb68-41fd-84ea-2cf910673599",
+  "barcode": "456",
+  "active": true,
+  "patronGroup": "3684a786-6671-4268-8ed0-9db82ebca60b",
+  "departments": [],
+  "proxyFor": [],
+  "personal": {
+    "lastName": "morty",
+    "firstName": "panic",
+    "email": "morty@example.com",
+    "addresses": [],
+    "preferredContactTypeId": "002"
+  },
+  "enrollmentDate": "2020-10-07T04:00:00.000+0000"
+}

--- a/src/main/resources/sample-data/users/User302.json
+++ b/src/main/resources/sample-data/users/User302.json
@@ -1,0 +1,16 @@
+{
+  "username": "sheldon",
+  "id": "b4cee18d-f862-4ef1-95a5-879fdd619603",
+  "barcode": "789",
+  "active": true,
+  "patronGroup": "3684a786-6671-4268-8ed0-9db82ebca60b",
+  "departments": [],
+  "proxyFor": [],
+  "personal": {
+    "lastName": "sheldon",
+    "firstName": "bazinga",
+    "email": "sheldon@example.com",
+    "addresses": [],
+    "preferredContactTypeId": "002"
+  }
+}

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -103,7 +103,7 @@ class UsersAPIIT {
       statusCode(200).
       body("resultInfo.facets[0].facetValues[0].count", is(88)).
       body("resultInfo.facets[0].facetValues[0].value", is("bdc2b6d4-5ceb-4a12-ab46-249b9a68473e")).
-      body("resultInfo.facets[0].facetValues[1].count", is(78)).
+      body("resultInfo.facets[0].facetValues[1].count", is(81)).
       body("resultInfo.facets[0].facetValues[1].value", is("3684a786-6671-4268-8ed0-9db82ebca60b"));
   }
 


### PR DESCRIPTION
https://samltest.id/ runs a test IdP for Single-Sign-On (SSO)
that FOLIO demo and test installations may use. It provides
3 demo users that should be added to the mod-users sample users
for ease of deployment. These are the usernames and passwords:

rick psych
morty panic
sheldon bazinga