### PR TITLE
MODUSERS-230: Upgrade to RMB v31.1.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,6 +403,7 @@
                   <manifestEntries>
                     <Main-Class>org.folio.rest.RestLauncher</Main-Class>
                     <Main-Verticle>org.folio.rest.RestVerticle</Main-Verticle>
+                    <Multi-Release>true</Multi-Release>
                   </manifestEntries>
                 </transformer>
               </transformers>
@@ -506,7 +507,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>31.1.0</raml-module-builder.version>
+    <raml-module-builder.version>31.1.2</raml-module-builder.version>
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.5.2</junit.version>
     <rest-assured.version>3.3.0</rest-assured.version>


### PR DESCRIPTION
https://issues.folio.org/browse/MODUSERS-230 - Upgrade to RAML Module Builder 31.1.2.

### Changes:

* Upgrade to the RMB 31.1.2;
* Vert.x 3.9.3 is already used.
* Add `Multi-Release` to prevent `WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.`

Tested on the team scratch env - following query `{{host}}/users?limit=150` return 150 users as expected.