### PR TITLE
MODUSERS-231: Release mod-users v17.2.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 17.2.1 2020-10-14
+
+* Upgraded to Module Builder 31.1.2 (MODUSERS-230)
+
 ## 17.2.0 2020-10-06
 
 * Allows users to be assigned to departments (MODUSERS-158)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>17.2.0</version>
+  <version>17.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -501,7 +501,7 @@
     <url>https://github.com/folio-org/mod-users</url>
     <connection>scm:git:git://github.com:folio-org/mod-users.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-users.git</developerConnection>
-    <tag>v17.2.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>17.2.1</version>
+  <version>17.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -501,7 +501,7 @@
     <url>https://github.com/folio-org/mod-users</url>
     <connection>scm:git:git://github.com:folio-org/mod-users.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-users.git</developerConnection>
-    <tag>v17.2.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>17.2.1-SNAPSHOT</version>
+  <version>17.2.1</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -501,7 +501,7 @@
     <url>https://github.com/folio-org/mod-users</url>
     <connection>scm:git:git://github.com:folio-org/mod-users.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-users.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v17.2.1</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -403,6 +403,7 @@
                   <manifestEntries>
                     <Main-Class>org.folio.rest.RestLauncher</Main-Class>
                     <Main-Verticle>org.folio.rest.RestVerticle</Main-Verticle>
+                    <Multi-Release>true</Multi-Release>
                   </manifestEntries>
                 </transformer>
               </transformers>
@@ -506,7 +507,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>31.1.0</raml-module-builder.version>
+    <raml-module-builder.version>31.1.2</raml-module-builder.version>
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.5.2</junit.version>
     <rest-assured.version>3.3.0</rest-assured.version>


### PR DESCRIPTION
https://issues.folio.org/browse/MODUSERS-231 - Release mod-users 17.2.1

Includes changes from https://github.com/folio-org/mod-users/pull/193 (MODUSERS-230: Upgrade to RMB v31.1.2.)