### PR TITLE
MODUSERS-233: Upgrade vert.x from 3.9.3 to 3.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.3</version>
+        <version>3.9.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release notes: https://github.com/vert-x3/wiki/wiki/3.9.4-Release-Notes

Most notable fix:
* RowStream fetch can close prematurely the stream
  https://github.com/eclipse-vertx/vertx-sql-client/issues/778