### PR TITLE
MODUSERS-234: Add property expiration offset to usergroup

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "users",
-      "version": "15.2",
+      "version": "15.3",
       "handlers" : [
         {
           "methods": [ "GET" ],

--- a/ramls/examples/group.sample
+++ b/ramls/examples/group.sample
@@ -1,6 +1,6 @@
 {
   "group": "librarian",
   "desc": "basic lib group",
-  "expirationOffset": 365,
+  "expirationOffsetInDays": 365,
   "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d"
 }

--- a/ramls/examples/group.sample
+++ b/ramls/examples/group.sample
@@ -1,5 +1,6 @@
 {
   "group": "librarian",
   "desc": "basic lib group",
+  "expirationOffset": 365,
   "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d"
 }

--- a/ramls/examples/groups.sample
+++ b/ramls/examples/groups.sample
@@ -3,6 +3,7 @@
     {
       "group": "librarian",
       "desc": "basic lib group",
+      "expirationOffset": 365,
       "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d"
     },
     {

--- a/ramls/examples/groups.sample
+++ b/ramls/examples/groups.sample
@@ -3,7 +3,7 @@
     {
       "group": "librarian",
       "desc": "basic lib group",
-      "expirationOffset": 365,
+      "expirationOffsetInDays": 365,
       "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d"
     },
     {

--- a/ramls/groups.raml
+++ b/ramls/groups.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: User Groups
-version: v1.0.1
+version: v1.1.0
 baseUri: http://github.com/org/folio/mod-users
 
 documentation:

--- a/ramls/groups.raml
+++ b/ramls/groups.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: User Groups
-version: v1.1.0
+version: v15.3
 baseUri: http://github.com/org/folio/mod-users
 
 documentation:

--- a/ramls/usergroup.json
+++ b/ramls/usergroup.json
@@ -17,7 +17,7 @@
       "type": "string"
     },
     "expirationOffsetInDays": {
-      "description": "The standard expiration offset in days of this group",
+      "description": "The default period in days after which a newly created user that belongs to this group will expire",
       "type": "integer"
     },
     "metadata": {

--- a/ramls/usergroup.json
+++ b/ramls/usergroup.json
@@ -16,7 +16,7 @@
       "description": "A UUID identifying this group",
       "type": "string"
     },
-    "expirationOffset": {
+    "expirationOffsetInDays": {
       "description": "The standard expiration offset in days of this group",
       "type": "integer"
     },

--- a/ramls/usergroup.json
+++ b/ramls/usergroup.json
@@ -16,6 +16,10 @@
       "description": "A UUID identifying this group",
       "type": "string"
     },
+    "expirationOffset": {
+      "description": "The standard expiration offset in days of this group",
+      "type": "integer"
+    },
     "metadata": {
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly": true

--- a/reference-data/groups/faculty.json
+++ b/reference-data/groups/faculty.json
@@ -1,5 +1,6 @@
 {
   "id" : "503a81cd-6c26-400f-b620-14c08943697c",
   "group":"faculty",
-  "desc":"Faculty Member"
+  "desc":"Faculty Member",
+  "expirationOffset": 365
 }

--- a/reference-data/groups/faculty.json
+++ b/reference-data/groups/faculty.json
@@ -2,5 +2,5 @@
   "id" : "503a81cd-6c26-400f-b620-14c08943697c",
   "group":"faculty",
   "desc":"Faculty Member",
-  "expirationOffset": 365
+  "expirationOffsetInDays": 365
 }

--- a/reference-data/groups/staff.json
+++ b/reference-data/groups/staff.json
@@ -1,5 +1,6 @@
 {
   "id" : "3684a786-6671-4268-8ed0-9db82ebca60b",
   "group":"staff",
-  "desc":"Staff Member"
+  "desc":"Staff Member",
+  "expirationOffset": 730
 }

--- a/reference-data/groups/staff.json
+++ b/reference-data/groups/staff.json
@@ -2,5 +2,5 @@
   "id" : "3684a786-6671-4268-8ed0-9db82ebca60b",
   "group":"staff",
   "desc":"Staff Member",
-  "expirationOffset": 730
+  "expirationOffsetInDays": 730
 }

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -63,7 +63,7 @@ public class GroupIT {
   private final String userUrl = HTTP_LOCALHOST + RestITSupport.port() + "/users";
   private final String groupUrl = HTTP_LOCALHOST + RestITSupport.port() + "/groups";
 
-  private static final String fooGroupData = "{\"group\": \"librarianFOO\",\"desc\": \"yet another basic lib group\"}";
+  private static final String fooGroupData = "{\"group\": \"librarianFOO\",\"desc\": \"yet another basic lib group\", \"expirationOffset\": 365}";
   private static final String barGroupData = "{\"group\": \"librarianBAR\",\"desc\": \"and yet another basic lib group\"}";
 
   private static final Logger log = LoggerFactory.getLogger(GroupIT.class);

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -63,7 +63,7 @@ public class GroupIT {
   private final String userUrl = HTTP_LOCALHOST + RestITSupport.port() + "/users";
   private final String groupUrl = HTTP_LOCALHOST + RestITSupport.port() + "/groups";
 
-  private static final String fooGroupData = "{\"group\": \"librarianFOO\",\"desc\": \"yet another basic lib group\", \"expirationOffset\": 365}";
+  private static final String fooGroupData = "{\"group\": \"librarianFOO\",\"desc\": \"yet another basic lib group\", \"expirationOffsetInDays\": 365}";
   private static final String barGroupData = "{\"group\": \"librarianBAR\",\"desc\": \"and yet another basic lib group\"}";
 
   private static final Logger log = LoggerFactory.getLogger(GroupIT.class);


### PR DESCRIPTION
Refs https://issues.folio.org/browse/MODUSERS-234

In order to implement [UIU-1908](https://issues.folio.org/browse/UIU-1908) we need a property describing the default expiration offset in days for a patron group.
This PR adds the optional property _expirationOffset_ to the _usergroup_ schema.