### PR TITLE
MODUSERS-235: Release 17.1.2 with RMB to 30.2.9 and Vert.x 3.9.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## 17.1.2 2020-10-23
+* [MODUSERS-235](https://issues.folio.org/browse/MODUSERS-235) Upgrade RMB to 30.2.9 and Vert.x to 3.9.4:
+  * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
+    the following two patches
+  * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
+  * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
+  * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fix: RowStream fetch
+    can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778
+
 ## 17.1.1 2020-10-15
 * [MODUSERS-226](https://issues.folio.org/browse/MODUSERS-226) Upgrade branch b17.1 (Goldenrod) to RMB 30.2.8 and release
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>17.1.2-SNAPSHOT</version>
+  <version>17.1.2</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -483,7 +483,7 @@
     <url>https://github.com/folio-org/mod-users</url>
     <connection>scm:git:git://github.com:folio-org/mod-users.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-users.git</developerConnection>
-    <tag>v17.1.0</tag>
+    <tag>v17.1.2</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,28 @@
     </repository>
   </repositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-sql-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-pg-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.folio</groupId>
@@ -40,12 +62,10 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -71,14 +91,12 @@
     <dependency>
        <groupId>io.vertx</groupId>
        <artifactId>vertx-unit</artifactId>
-       <version>${vertx.version}</version>
        <scope>test</scope>
        <type>jar</type>
     </dependency>
     <dependency>
        <groupId>io.vertx</groupId>
        <artifactId>vertx-junit5</artifactId>
-       <version>${vertx.version}</version>
        <scope>test</scope>
     </dependency>
     <dependency>
@@ -108,7 +126,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -474,9 +491,9 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <raml-module-builder.version>30.2.8</raml-module-builder.version>
+    <raml-module-builder.version>30.2.9</raml-module-builder.version>
     <generate_routing_context>/users</generate_routing_context>
-    <vertx.version>3.9.1</vertx.version>
+    <vertx.version>3.9.4</vertx.version>
     <junit.version>5.5.2</junit.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <folio-service-tools.version>1.5.1</folio-service-tools.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>17.1.2</version>
+  <version>17.1.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -483,7 +483,7 @@
     <url>https://github.com/folio-org/mod-users</url>
     <connection>scm:git:git://github.com:folio-org/mod-users.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-users.git</developerConnection>
-    <tag>v17.1.2</tag>
+    <tag>v17.1.0</tag>
   </scm>
 
   <properties>


### PR DESCRIPTION
* [MODUSERS-235](https://issues.folio.org/browse/MODUSERS-235) Upgrade RMB to 30.2.9 and Vert.x to 3.9.4:
  * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
    the following two patches
  * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
  * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
  * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fix: RowStream fetch
    can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778