### PR TITLE
MODUSERS-237: Upgrade to RMB 31.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,19 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.4</version>
+        <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-sql-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-pg-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -507,7 +517,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>31.1.3</raml-module-builder.version>
+    <raml-module-builder.version>31.1.5</raml-module-builder.version>
+    <vertx.version>3.9.4</vertx.version>
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.5.2</junit.version>
     <rest-assured.version>3.3.0</rest-assured.version>


### PR DESCRIPTION
RMB 31.1.5 provides

* RMB-750 Change lock for "tuple concurrently updated" when upgrading Q2 to Q3 (REVOKE)

RMB 31.1.4 provides

* RMB-744 fix "tuple concurrently updated" when upgrading Q2 to Q3 (REVOKE)

The FOLIO fork of vertx-sql-client and vertx-pg-client provides

* RMB-739 Make RMB's DB_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
* FOLIO-2840 Fix duplicate names causing 'prepared statement "XYZ" already exists'