### PR TITLE
Upgrade to RAML Module Builder 33.0.0 MODUSERS-255

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 18.0.0 IN-PROGRESS
+
+* `embed_postgres` command line option is no longer supported (MODUSERS-255)
+* Upgrades to RAML Module Builder 33.0.0 (MODUSERS-255)
+* Upgrades to 4.1.0.CR1 (MODUSERS-255)
+
 ## 17.3.0 2021-03-09
 
 * Groups can define a default period after which a user should expire (MODUSERS-234)

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,14 @@
     </repository>
   </repositories>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>folio-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://repository.folio.org/repository/maven-folio</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -75,6 +83,11 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -152,43 +165,52 @@
 
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.5.0</version>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>jsonschema2pojo.config.includeToString</name>
+                  <value>true</value>
+                </property>
+                <property>
+                  <name>jsonschema2pojo.config.includeHashcodeAndEquals</name>
+                  <value>true</value>
+                </property>
+                <property>
+                  <name>jsonschema2pojo.config.useCommonsLang3</name>
+                  <value>true</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>domain-models-maven-plugin</artifactId>
+        <version>${raml-module-builder.version}</version>
         <executions>
           <execution>
             <id>generate_interfaces</id>
-            <phase>generate-sources</phase>
             <goals>
               <goal>java</goal>
             </goals>
-            <configuration>
-              <mainClass>org.folio.rest.tools.GenerateRunner</mainClass>
-              <!-- <executable>java</executable> -->
-              <cleanupDaemonThreads>false</cleanupDaemonThreads>
-              <systemProperties>
-                <systemProperty>
-                  <key>project.basedir</key>
-                  <value>${basedir}</value>
-                </systemProperty>
-                <systemProperty>
-                  <key>raml_files</key>
-                  <value>${ramlfiles_path}</value>
-                </systemProperty>
-                <systemProperty>
-                  <key>jsonschema2pojo.config.includeToString</key>
-                  <value>true</value>
-                </systemProperty>
-                <systemProperty>
-                  <key>jsonschema2pojo.config.includeHashcodeAndEquals</key>
-                  <value>true</value>
-                </systemProperty>
-                <systemProperty>
-                  <key>jsonschema2pojo.config.useCommonsLang3</key>
-                  <value>true</value>
-                </systemProperty>
-              </systemProperties>
-            </configuration>
           </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.5.0</version>
+        <executions>
           <execution>
             <id>git submodule update</id>
             <phase>initialize</phase>
@@ -518,13 +540,13 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>32.2.0</raml-module-builder.version>
+    <raml-module-builder.version>33.0.0</raml-module-builder.version>
     <vertx.version>4.1.0.CR1</vertx.version>
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.5.2</junit.version>
     <rest-assured.version>3.3.0</rest-assured.version>
-    <folio-service-tools.version>1.6.1</folio-service-tools.version>
-    <folio-custom-fields.version>1.5.2</folio-custom-fields.version>
+    <folio-service-tools.version>1.6.2-SNAPSHOT</folio-service-tools.version>
+    <folio-custom-fields.version>1.5.3-SNAPSHOT</folio-custom-fields.version>
     <jsoup.version>1.13.1</jsoup.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>32.1.0</raml-module-builder.version>
+    <raml-module-builder.version>32.2.0</raml-module-builder.version>
     <vertx.version>4.0.0</vertx.version>
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.5.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <raml-module-builder.version>32.2.0</raml-module-builder.version>
-    <vertx.version>4.0.0</vertx.version>
+    <vertx.version>4.1.0.CR1</vertx.version>
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.5.2</junit.version>
     <rest-assured.version>3.3.0</rest-assured.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
+      <artifactId>postgres-testing</artifactId>
+      <version>${raml-module-builder.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
       <artifactId>folio-service-tools-test</artifactId>
       <version>${folio-service-tools.version}</version>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>17.4.0-SNAPSHOT</version>
+  <version>18.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -210,10 +210,6 @@
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
           <complianceLevel>11</complianceLevel>
-          <includes>
-            <include>**/impl/*.java</include>
-            <include>**/*.aj</include>
-          </includes>
           <aspectDirectory>src/main/java/org/folio/rest/annotations</aspectDirectory>
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>true</showWeaveInfo>

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.CQL2PgJSONException;

--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -16,6 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.lang.RandomStringUtils;
+import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Errors;
@@ -87,13 +88,15 @@ public class CustomFieldIT {
 
 
   private static Vertx vertx;
-  
+
   @Rule
   public Timeout rule = Timeout.seconds(20);
 
   @BeforeClass
   public static void setup(TestContext context) {
     vertx = Vertx.vertx();
+
+    PostgresClient.setPostgresTester(new PostgresTesterContainer());
 
     Integer port = NetworkUtils.nextFreePort();
     RestITSupport.setUp(port);

--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
@@ -112,15 +112,6 @@ public class CustomFieldIT {
       parameters.add(new Parameter().withKey("loadSample").withValue("false"));
       ta.setParameters(parameters);
       TenantInit.init(tenantClient, ta).onComplete(context.asyncAssertSuccess());
-    }));
-  }
-
-  @AfterClass
-  public static void teardown(TestContext context) {
-    Async async = context.async();
-    vertx.close(context.asyncAssertSuccess(res -> {
-      PostgresClient.stopEmbeddedPostgres();
-      async.complete();
     }));
   }
 

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Parameter;
@@ -79,6 +80,8 @@ public class GroupIT {
   @BeforeClass
   public static void setup(TestContext context) {
     vertx = Vertx.vertx();
+
+    PostgresClient.setPostgresTester(new PostgresTesterContainer());
 
     Integer port = NetworkUtils.nextFreePort();
     RestITSupport.setUp(port);

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -100,15 +100,6 @@ public class GroupIT {
     }));
   }
 
-  @AfterClass
-  public static void teardown(TestContext context) {
-    Async async = context.async();
-    vertx.close(context.asyncAssertSuccess(res -> {
-      PostgresClient.stopEmbeddedPostgres();
-      async.complete();
-    }));
-  }
-
   @Test
   public void test2Group(TestContext context) throws Exception {
     /*

--- a/src/test/java/org/folio/moduserstest/RestVerticleIT.java
+++ b/src/test/java/org/folio/moduserstest/RestVerticleIT.java
@@ -124,15 +124,6 @@ public class RestVerticleIT {
     }));
   }
 
-  @AfterClass
-  public static void teardown(TestContext context) {
-    Async async = context.async();
-      vertx.close(context.asyncAssertSuccess(res -> {
-      PostgresClient.stopEmbeddedPostgres();
-      async.complete();
-    }));
-  }
-
   private Future<Void> getEmptyUsers(TestContext context) {
     log.info("Getting an empty user set\n");
 

--- a/src/test/java/org/folio/moduserstest/RestVerticleIT.java
+++ b/src/test/java/org/folio/moduserstest/RestVerticleIT.java
@@ -39,6 +39,8 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.HttpResponse;
+
+import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.utils.TenantInit;
 import org.joda.time.DateTime;
 import org.junit.AfterClass;
@@ -91,15 +93,17 @@ public class RestVerticleIT {
     .put("requestForSponsor", "Yes")
     .put("notificationsTo", "Proxy")
     .put("accrueTo", "Sponsor");
-  
+
   private static Vertx vertx;
-  
+
   @Rule
   public Timeout rule = Timeout.seconds(20);
 
   @BeforeClass
   public static void setup(TestContext context) {
     vertx = Vertx.vertx();
+
+    PostgresClient.setPostgresTester(new PostgresTesterContainer());
 
     Integer port = NetworkUtils.nextFreePort();
     RestITSupport.setUp(port);
@@ -128,7 +132,7 @@ public class RestVerticleIT {
       async.complete();
     }));
   }
-  
+
   private Future<Void> getEmptyUsers(TestContext context) {
     log.info("Getting an empty user set\n");
 

--- a/src/test/java/org/folio/moduserstest/UserGroupAPITest.java
+++ b/src/test/java/org/folio/moduserstest/UserGroupAPITest.java
@@ -36,15 +36,6 @@ public class UserGroupAPITest {
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
   }
 
-  @AfterClass
-  public static void teardown(TestContext context) {
-    Async async = context.async();
-    vertx.close(context.asyncAssertSuccess(res -> {
-      PostgresClient.stopEmbeddedPostgres();
-      async.complete();
-    }));
-  }
-
   @Test
   public void postException(TestContext context) {
     new MyUserGroupAPI().postGroups("en", new Usergroup(), Collections.emptyMap(), context.asyncAssertSuccess(result -> {

--- a/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
@@ -81,7 +81,8 @@ public class CustomFieldTestBase extends TestBase {
   }
 
   protected void updateField(CustomField field) {
-    putWithStatus(cfByIdEndpoint(field.getId()), Json.encode(field), SC_NO_CONTENT, FAKE_TOKEN);
+    putWithStatus(cfByIdEndpoint(field.getId()), Json.encode(field),
+      SC_NO_CONTENT, FAKE_TOKEN, FAKE_USER_ID);
   }
 
   protected void deleteField(String fieldId) {

--- a/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 
+import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 import static org.folio.test.util.TestUtil.mockGetWithBody;
 import static org.folio.test.util.TestUtil.readFile;
 import static org.folio.test.util.TestUtil.toJson;
@@ -26,9 +27,9 @@ import org.folio.test.util.TestBase;
 import org.folio.test.util.TokenTestUtil;
 
 public class CustomFieldTestBase extends TestBase {
-
   protected static final String USER_ID = "88888888-8888-4888-8888-888888888888";
   protected static final Header FAKE_TOKEN = TokenTestUtil.createTokenHeader("mockuser8", USER_ID);
+  protected static final Header FAKE_USER_ID = new Header(OKAPI_USERID_HEADER, USER_ID);
 
   private static final String USERS_ENDPOINT = "users";
   private static final String CUSTOM_FIELDS_ENDPOINT = "custom-fields";
@@ -124,7 +125,8 @@ public class CustomFieldTestBase extends TestBase {
   }
 
   private CustomField createField(String pathToJson) {
-    return postWithStatus(cfEndpoint(), readExistedFile(pathToJson), SC_CREATED, FAKE_TOKEN).as(CustomField.class);
+    return postWithStatus(cfEndpoint(), readExistedFile(pathToJson), SC_CREATED,
+      FAKE_TOKEN, FAKE_USER_ID).as(CustomField.class);
   }
 
   private String readExistedFile(String pathToJson) {

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -17,9 +17,12 @@ import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
+import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
@@ -45,6 +48,9 @@ class UsersAPIIT {
   @BeforeAll
   static void beforeAll() {
     vertx = Vertx.vertx();
+
+    PostgresClient.setPostgresTester(new PostgresTesterContainer());
+
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     RestAssured.port = NetworkUtils.nextFreePort();
     baseUrl = "http://localhost:" + RestAssured.port;
@@ -120,12 +126,12 @@ class UsersAPIIT {
     given().
     when().get("/users?limit=" + limit + "&facets=patronGroup:50").
     then().
-      statusCode(200). 
+      statusCode(200).
       body("resultInfo.facets[0].facetValues[0].count", is(88)).
       body("resultInfo.facets[0].facetValues[0].value", is("bdc2b6d4-5ceb-4a12-ab46-249b9a68473e")).
       body("resultInfo.facets[0].facetValues[1].count", is(81)).
       body("resultInfo.facets[0].facetValues[1].value", is("3684a786-6671-4268-8ed0-9db82ebca60b"));
-      
+
   }
 
   @Disabled("fails, bug")  // https://issues.folio.org/browse/UIU-1562  https:/issues.folio.org/browse/RMB-722

--- a/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
+++ b/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
@@ -57,7 +57,7 @@ public class ExpirationToolTest {
   void expirationForTenantCanHandleException(Vertx vertx, VertxTestContext context) {
     PostgresClient postgresClient = mock(PostgresClient.class);
     doThrow(new RuntimeException("pg"))
-      .when(postgresClient).get(anyString(), any(Class.class), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), any());
+      .when(postgresClient).get(anyString(), any(Class.class), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), any(Handler.class));
     ExpirationTool.postgresClient = (v,t) -> postgresClient;
     Future<Integer> future = ExpirationTool.doExpirationForTenant(vertx, "someTenant");
     future.onComplete(context.failing(e -> context.verify(() -> {


### PR DESCRIPTION
The custom fields tests needed to be changed as during the upgrade of `folio-custom-fields` to RMB 33.0.0 there was also a change from using the `X-Okapi-Token` header to the `X-Okapi-User-Id` header to determine which user created the custom field. 

If this header is not present, the process to find the users fails reporting a 401 (this is not a response from the self-referential API request, rather a fake response when the header is not provided or blank).

There is also a change to the configuration of the AspectJ plugin in order to improve the reliability of the departments tests (yes, this probably should be a separate pull request)