### PR TITLE
consolidating plugin entries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,36 +162,6 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <version>1.0.0</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-            <configuration>
-              <properties>
-                <property>
-                  <name>jsonschema2pojo.config.includeToString</name>
-                  <value>true</value>
-                </property>
-                <property>
-                  <name>jsonschema2pojo.config.includeHashcodeAndEquals</name>
-                  <value>true</value>
-                </property>
-                <property>
-                  <name>jsonschema2pojo.config.useCommonsLang3</name>
-                  <value>true</value>
-                </property>
-              </properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.folio</groupId>
         <artifactId>domain-models-maven-plugin</artifactId>
@@ -412,6 +382,18 @@
         </executions>
         <configuration>
           <properties>
+            <property>
+              <name>jsonschema2pojo.config.includeToString</name>
+              <value>true</value>
+            </property>
+            <property>
+              <name>jsonschema2pojo.config.includeHashcodeAndEquals</name>
+              <value>true</value>
+            </property>
+            <property>
+              <name>jsonschema2pojo.config.useCommonsLang3</name>
+              <value>true</value>
+            </property>
             <property>
               <name>log4j.configurationFile</name>
               <value>${project.baseUri}src/main/resources/log4j2.properties</value>


### PR DESCRIPTION
While trying to build the release, got a warning the pomfile
had two entries for the same plugin, and this could cause 
instability and might cause build failures in future.  Checked 
the pomfile and this did seem to be the case, so I consolidated 
the two entries.  Re-ran tests to make sure this didn't break anything.