### PR TITLE
MODUSERS-264: Fix indentation of UsersAPI.java

### DIFF
--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -134,10 +134,10 @@ public class UsersAPI implements Users {
   @Validate
   @Override
   public void getUsers(String query, String orderBy,
-    UsersGetOrder order, int offset, int limit, List<String> facets,
-    String lang, RoutingContext routingContext, Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      UsersGetOrder order, int offset, int limit, List<String> facets,
+      String lang, RoutingContext routingContext, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
 
     try {
       logger.debug("Getting users");
@@ -160,10 +160,11 @@ public class UsersAPI implements Users {
   @Validate
   @Override
   public void postUsers(String lang, User entity,
-                        RoutingContext routingContext,
-                        Map<String, String> okapiHeaders,
-                        Handler<AsyncResult<Response>> asyncResultHandler,
-                        Context vertxContext) {
+      RoutingContext routingContext,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+
     try {
       if (checkForDuplicateAddressTypes(entity)) {
         asyncResultHandler.handle(Future.succeededFuture(
@@ -221,6 +222,7 @@ public class UsersAPI implements Users {
 
   private void saveUser(User entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
+
     Date now = new Date();
     entity.setCreatedDate(now);
     entity.setUpdatedDate(now);
@@ -270,11 +272,11 @@ public class UsersAPI implements Users {
     if (reply.succeeded()) {
       if (reply.result().getStatus() == 400) {
         return reply.result().getEntity().toString().matches(errMsg);
-  }
+      }
       if (reply.result().getStatus() == 422) {
         String msg = ((Errors)reply.result().getEntity()).getErrors().iterator().next().getMessage();
         return msg.matches(errMsg);
-  }
+      }
     }
     return false;
   }
@@ -282,9 +284,9 @@ public class UsersAPI implements Users {
   @Validate
   @Override
   public void getUsersByUserId(String userId, String lang,
-          Map<String, String> okapiHeaders,
-          Handler<AsyncResult<Response>> asyncResultHandler,
-          Context vertxContext) {
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
     PgUtil.getById(getTableName(null), User.class, userId, okapiHeaders, vertxContext,
       GetUsersByUserIdResponse.class, asyncResultHandler);
   }
@@ -292,9 +294,9 @@ public class UsersAPI implements Users {
   @Validate
   @Override
   public void deleteUsersByUserId(String userId, String lang,
-          Map<String, String> okapiHeaders,
-          Handler<AsyncResult<Response>> asyncResultHandler,
-          Context vertxContext) {
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
     PgUtil.deleteById(getTableName(null), userId, okapiHeaders, vertxContext,
       DeleteUsersByUserIdResponse.class, asyncResultHandler);
   }
@@ -302,10 +304,11 @@ public class UsersAPI implements Users {
   @Validate
   @Override
   public void putUsersByUserId(String userId,
-          String lang, User entity,
-          Map<String, String> okapiHeaders,
-          Handler<AsyncResult<Response>> asyncResultHandler,
-          Context vertxContext) {
+      String lang, User entity,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+
     try {
       Future.succeededFuture()
         .compose(o -> new ValidationServiceImpl(vertxContext)
@@ -362,7 +365,8 @@ public class UsersAPI implements Users {
 
   @Override
   public void postUsersExpireTimer(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-                              Context vertxContext) {
+      Context vertxContext) {
+
     ExpirationTool.doExpirationForTenant(vertxContext.owner(), okapiHeaders.get("x-okapi-tenant"))
         .onSuccess(res -> asyncResultHandler.handle(
             Future.succeededFuture(PostUsersExpireTimerResponse.respond204())))
@@ -371,7 +375,8 @@ public class UsersAPI implements Users {
   }
 
   private void updateUser(User entity, Map<String, String> okapiHeaders,
-                          Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
     Date now = new Date();
     entity.setCreatedDate(now);
     entity.setUpdatedDate(now);
@@ -405,8 +410,9 @@ public class UsersAPI implements Users {
    *                -1 if exception was thrown
    */
   private void checkPatronGroupExists(String patronGroupId,
-                                      PostgresClient postgresClient,
-                                      Handler<AsyncResult<Integer>> handler) {
+      PostgresClient postgresClient,
+      Handler<AsyncResult<Integer>> handler) {
+
     if (patronGroupId == null) {
       //allow null patron groups so that they can be added after a record is created
       handler.handle(io.vertx.core.Future.succeededFuture(1));
@@ -439,9 +445,10 @@ public class UsersAPI implements Users {
    * @param onSuccess handler that will be called on validation success
    */
   private void validatePatronGroup(String patronGroupId,
-                                   PostgresClient postgresClient,
-                                   Handler<AsyncResult<Response>> asyncResultHandler,
-                                   Handler<AsyncResult<Void>> onSuccess) {
+      PostgresClient postgresClient,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Handler<AsyncResult<Void>> onSuccess) {
+
     checkPatronGroupExists(patronGroupId, postgresClient, handler -> {
       int res = handler.result();
       if (res == 0) {


### PR DESCRIPTION
https://dev.folio.org/guidelines/contributing/#style-conventions

suggests:

    We indent with two spaces only, because vert.x uses deeply nested callbacks.

This changes the line wrap indentation suggested by Sun Java Code style from 8 spaces to 4 spaces because line wrapping uses two indentation levels:

https://www.oracle.com/java/technologies/javase/codeconventions-indentation.html

4 spaces also complies with Google Java Style Guide: https://google.github.io/styleguide/javaguide.html#s4.5.2-line-wrapping-indent