### PR TITLE
MODUSERS-265: Reformat methods with multi-line parameter list

### DIFF
--- a/src/main/java/org/folio/rest/impl/AddressTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/AddressTypeAPI.java
@@ -31,7 +31,7 @@ public class AddressTypeAPI implements Addresstypes {
   public static final String ADDRESS_TYPE_USER_JOIN_TABLE = "address_users";
   public static final String ID_FIELD_NAME = "id";
   public static final String URL_PREFIX = "/addresstypes";
-  private static final Logger logger = LogManager.getLogger(AddressTypeAPI.class); 
+  private static final Logger logger = LogManager.getLogger(AddressTypeAPI.class);
   private boolean suppressErrorResponse = false;
 
   private String getErrorResponse(String response) {
@@ -44,32 +44,35 @@ public class AddressTypeAPI implements Addresstypes {
   @Validate
   @Override
   public void getAddresstypes(String query, int offset, int limit, String lang,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+
     PgUtil.get(ADDRESS_TYPE_TABLE, AddressType.class, AddresstypeCollection.class,
       query, offset, limit, okapiHeaders, vertxContext, GetAddresstypesResponse.class, asyncResultHandler);
   }
 
   @Override
   public void postAddresstypes(String lang, AddressType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      Context vertxContext) {
+
     PgUtil.post(ADDRESS_TYPE_TABLE, entity, okapiHeaders, vertxContext,
       PostAddresstypesResponse.class, asyncResultHandler);
   }
 
   @Override
   public void getAddresstypesByAddresstypeId(String addresstypeId, String lang,
-    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+
     PgUtil.getById(ADDRESS_TYPE_TABLE, AddressType.class, addresstypeId, okapiHeaders,
       vertxContext, GetAddresstypesByAddresstypeIdResponse.class, asyncResultHandler);
   }
 
   @Override
   public void deleteAddresstypesByAddresstypeId(String addresstypeId, String lang,
-    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
 
     try {
       //Check to make certain no users' addresses are currently using this type
@@ -112,8 +115,8 @@ public class AddressTypeAPI implements Addresstypes {
 
   @Override
   public void putAddresstypesByAddresstypeId(String addresstypeId, String lang,
-    AddressType entity, Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      AddressType entity, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     PgUtil.put(ADDRESS_TYPE_TABLE, entity, addresstypeId, okapiHeaders,
       vertxContext, PutAddresstypesByAddresstypeIdResponse.class, asyncResultHandler);

--- a/src/main/java/org/folio/rest/impl/DepartmentsAPI.java
+++ b/src/main/java/org/folio/rest/impl/DepartmentsAPI.java
@@ -40,7 +40,8 @@ public class DepartmentsAPI implements Departments {
   @Validate
   @Override
   public void getDepartments(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders,
-                             Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
+      Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
+
     get(DEPARTMENTS_VIEW_NAME, Department.class, DepartmentCollection.class, query, offset, limit,
       okapiHeaders, vertxContext, GetDepartmentsResponse.class, resultHandler);
   }
@@ -48,7 +49,8 @@ public class DepartmentsAPI implements Departments {
   @Validate
   @Override
   public void postDepartments(String lang, Department entity, Map<String, String> okapiHeaders,
-                              Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
+      Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
+
     post(DEPARTMENTS_TABLE_NAME, entity, okapiHeaders, vertxContext, PostDepartmentsResponse.class, result ->
       handleUniqueConstraintViolation(result, entity, PostDepartmentsResponse::respond422WithApplicationJson, resultHandler)
     );
@@ -68,7 +70,8 @@ public class DepartmentsAPI implements Departments {
   @Validate
   @Override
   public void getDepartmentsByDepartmentId(String departmentId, String lang, Map<String, String> okapiHeaders,
-                                           Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
+      Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
+
     getById(DEPARTMENTS_VIEW_NAME, Department.class, departmentId, okapiHeaders, vertxContext,
       GetDepartmentsByDepartmentIdResponse.class, resultHandler);
   }
@@ -76,14 +79,16 @@ public class DepartmentsAPI implements Departments {
   @Validate
   @Override
   public void deleteDepartmentsByDepartmentId(String departmentId, String lang, Map<String, String> okapiHeaders,
-                                              Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
+      Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
+
     deleteById(DEPARTMENTS_TABLE_NAME, departmentId, okapiHeaders, vertxContext,
       DeleteDepartmentsByDepartmentIdResponse.class, resultHandler);
   }
 
   static void handleUniqueConstraintViolation(AsyncResult<Response> result, Department entity,
-                                               Function<Errors, Response> errorsMapFunction,
-                                               Handler<AsyncResult<Response>> resultHandler) {
+      Function<Errors, Response> errorsMapFunction,
+      Handler<AsyncResult<Response>> resultHandler) {
+
     AsyncResult<Response> finalResult = result;
     try {
       Errors error = null;

--- a/src/main/java/org/folio/rest/impl/ProxiesForAPI.java
+++ b/src/main/java/org/folio/rest/impl/ProxiesForAPI.java
@@ -48,11 +48,12 @@ public class ProxiesForAPI implements Proxiesfor {
 
   @Override
   public void getProxiesfor(String query,
-    int offset, int limit,
-    String lang,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      int offset, int limit,
+      String lang,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+
     PgUtil.get(PROXY_FOR_TABLE, ProxiesFor.class, ProxyforCollection.class,
       query, offset, limit, okapiHeaders, vertxContext,
       GetProxiesforResponse.class, asyncResultHandler);
@@ -60,11 +61,12 @@ public class ProxiesForAPI implements Proxiesfor {
 
   @Override
   public void postProxiesfor(
-    String lang,
-    ProxiesFor entity,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      String lang,
+      ProxiesFor entity,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+
     PostgresClient postgresClient = PgUtil.postgresClient(vertxContext, okapiHeaders);
     userAndProxyUserComboExists(entity.getUserId(), entity.getProxyUserId(),
       postgresClient).onComplete(existsRes -> {
@@ -91,38 +93,42 @@ public class ProxiesForAPI implements Proxiesfor {
 
   @Override
   public void getProxiesforById(String id,
-    String lang,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      String lang,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+
     PgUtil.getById(PROXY_FOR_TABLE, ProxiesFor.class, id, okapiHeaders,
       vertxContext, GetProxiesforByIdResponse.class, asyncResultHandler);
   }
 
   @Override
   public void deleteProxiesforById(String id,
-    String lang,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      String lang,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+
     PgUtil.deleteById(PROXY_FOR_TABLE, id, okapiHeaders, vertxContext,
       DeleteProxiesforByIdResponse.class, asyncResultHandler);
   }
 
   @Override
   public void putProxiesforById(String id,
-    String lang,
-    ProxiesFor entity,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      String lang,
+      ProxiesFor entity,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+
     PgUtil.put(PROXY_FOR_TABLE, entity, id, okapiHeaders, vertxContext, PutProxiesforByIdResponse.class, asyncResultHandler);
   }
 
   Future<Boolean> userAndProxyUserComboExists(
-    String userId,
-    String proxyUserId,
-    PostgresClient postgresClient) {
+      String userId,
+      String proxyUserId,
+      PostgresClient postgresClient) {
+
     Promise<Boolean> promise = Promise.promise();
     Criteria userCrit = new Criteria().addField(USERID_FIELD_NAME).
       setOperation("=").setVal(userId).setJSONB(true);

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -17,8 +17,8 @@ public class TenantRefAPI extends TenantAPI {
   @Validate
   @Override
   Future<Integer> loadData(TenantAttributes attributes, String tenantId,
-    Map<String, String> headers, Context vertxContext) {
-      
+      Map<String, String> headers, Context vertxContext) {
+
     return super.loadData(attributes, tenantId, headers, vertxContext)
         .compose(superRecordsLoaded -> {
           log.info("loading data to tenant");
@@ -34,7 +34,7 @@ public class TenantRefAPI extends TenantAPI {
           tl.withKey("loadSample").withLead("sample-data");
           tl.withIdContent();
           tl.add("users");
-          
+
           return tl.perform(attributes, headers, vertxContext, superRecordsLoaded);
         });
   }

--- a/src/main/java/org/folio/rest/impl/UserGroupAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserGroupAPI.java
@@ -29,8 +29,8 @@ public class UserGroupAPI implements Groups {
   @Validate
   @Override
   public void getGroups(String query, int offset, int limit,
-    String lang, Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     PgUtil.get(GROUP_TABLE, Usergroup.class, Usergroups.class, query, offset, limit, okapiHeaders,
       vertxContext, GetGroupsResponse.class, asyncResultHandler);
@@ -39,9 +39,9 @@ public class UserGroupAPI implements Groups {
   @Validate
   @Override
   public void postGroups(String lang, Usergroup entity,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
 
     PgUtil.post(GROUP_TABLE, entity, okapiHeaders, vertxContext, PostGroupsResponse.class, post -> {
       try {
@@ -63,7 +63,7 @@ public class UserGroupAPI implements Groups {
   @Validate
   @Override
   public void getGroupsByGroupId(String groupId, String lang, Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     PgUtil.getById(GROUP_TABLE, Usergroup.class, groupId, okapiHeaders, vertxContext,
         GetGroupsByGroupIdResponse.class, asyncResultHandler);
@@ -72,7 +72,7 @@ public class UserGroupAPI implements Groups {
   @Validate
   @Override
   public void deleteGroupsByGroupId(String groupId, String lang, Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     PgUtil.deleteById(GROUP_TABLE, groupId, okapiHeaders, vertxContext,
       DeleteGroupsByGroupIdResponse.class, asyncResultHandler);
@@ -81,8 +81,8 @@ public class UserGroupAPI implements Groups {
   @Validate
   @Override
   public void putGroupsByGroupId(String groupId, String lang, Usergroup entity,
-    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
 
     PgUtil.put(GROUP_TABLE, entity, groupId, okapiHeaders, vertxContext,
         PutGroupsByGroupIdResponse.class, asyncResultHandler);

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -112,6 +112,7 @@ public class UsersAPI implements Users {
 
   static Response response(String message, Throwable e, String lang,
       Function<String,Response> report400, Function<String,Response> report500) {
+
     try {
       Throwable cause = e;
       while (cause != null) {
@@ -286,6 +287,7 @@ public class UsersAPI implements Users {
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
+
     PgUtil.getById(getTableName(null), User.class, userId, okapiHeaders, vertxContext,
       GetUsersByUserIdResponse.class, asyncResultHandler);
   }
@@ -296,6 +298,7 @@ public class UsersAPI implements Users {
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
+
     PgUtil.deleteById(getTableName(null), userId, okapiHeaders, vertxContext,
       DeleteUsersByUserIdResponse.class, asyncResultHandler);
   }
@@ -306,6 +309,7 @@ public class UsersAPI implements Users {
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
+
     PgUtil.delete(getTableName(null), query, okapiHeaders, vertxContext,
         DeleteUsersResponse.class, asyncResultHandler);
   }

--- a/src/main/java/org/folio/service/impl/RecordRepositoryImpl.java
+++ b/src/main/java/org/folio/service/impl/RecordRepositoryImpl.java
@@ -50,7 +50,8 @@ public class RecordRepositoryImpl implements RecordRepository {
 
   @Override
   public Future<CustomFieldOptionStatistic> retrieveStatisticForFieldOption(CustomField field, String optId,
-                                                                            String tenantId) {
+      String tenantId) {
+
     Promise<RowSet<Row>> count = Promise.promise();
 
     Tuple params = Tuple.of(field.getRefId(), optId);

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -426,7 +426,8 @@ public class GroupIT {
   }
 
   private CompletableFuture<Response> send(String url, HttpMethod method, String content,
-                                           Function<HttpResponse<Buffer>, Response> handler) {
+      Function<HttpResponse<Buffer>, Response> handler) {
+
     Future<HttpResponse<Buffer>> httpResponse;
 
     switch (method.name()) {

--- a/src/test/java/org/folio/moduserstest/RestITSupport.java
+++ b/src/test/java/org/folio/moduserstest/RestITSupport.java
@@ -89,7 +89,8 @@ class RestITSupport {
   }
 
   static void fail(TestContext context, String message, HttpResponse<Buffer> response,
-                           StackTraceElement [] stacktrace) {
+      StackTraceElement [] stacktrace) {
+
     Async async = context.async();
 
     Throwable t = new AssertionFailedError((message == null ? "" : message + ": ")
@@ -120,7 +121,8 @@ class RestITSupport {
   }
 
   static Future<HttpResponse<Buffer>> post(String request, String body,
-                                           Map<String, String> additionalHeaders) {
+      Map<String, String> additionalHeaders) {
+
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
 
     HttpRequest<Buffer> req = client.post(port, LOCALHOST, request)

--- a/src/test/java/org/folio/moduserstest/RestVerticleIT.java
+++ b/src/test/java/org/folio/moduserstest/RestVerticleIT.java
@@ -1123,7 +1123,8 @@ public class RestVerticleIT {
   }
 
   private Future<Void> createTestDeleteObjectById(TestContext context, JsonObject ob,
-                                                  String endpoint, boolean checkMeta) {
+      String endpoint, boolean checkMeta) {
+
     log.info(String.format(
       "Creating object %s at endpoint %s", ob.encode(), endpoint));
 


### PR DESCRIPTION
If the parameter list of a method is broken into multiple lines indent by 4 spaces and put an empty line after the parameter list.

Requested on https://github.com/folio-org/mod-users/pull/207

This complies with

* https://google.github.io/styleguide/javaguide.html#s4.5.2-line-wrapping-indent and
* https://www.oracle.com/java/technologies/javase/codeconventions-indentation.html#248 and
* https://dev.folio.org/guidelines/contributing/#consistent-whitespace