### PR TITLE
MODUSERS-272: Update RMB to 33.1.1 and Vert.x to 4.1.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 18.1.1 2021-10-04
+## 18.1.1
 
 * Update RMB to 33.1.1 and Vert.x to 4.1.4 (MODUSERS-272)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 18.1.1 2021-10-04
+
+* Update RMB to 33.1.1 and Vert.x to 4.1.4 (MODUSERS-272)
+
 ## 18.1.0 2021-09-28
 
 * Characters in department name and code now properly saved (MODUSERS-260)

--- a/pom.xml
+++ b/pom.xml
@@ -38,16 +38,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -65,7 +55,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.10.6</version>
+      <version>2.10.12</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -517,13 +507,13 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <raml-module-builder.version>33.1.1</raml-module-builder.version>
+    <vertx.version>4.1.4</vertx.version>
     <generate_routing_context>/users</generate_routing_context>
-    <junit.version>5.5.2</junit.version>
-    <rest-assured.version>3.3.0</rest-assured.version>
-    <folio-service-tools.version>1.7.0</folio-service-tools.version>
-    <folio-custom-fields.version>1.6.0</folio-custom-fields.version>
+    <junit.version>5.8.1</junit.version>
+    <rest-assured.version>4.4.0</rest-assured.version>
+    <folio-service-tools.version>1.7.1</folio-service-tools.version>
+    <folio-custom-fields.version>1.6.1</folio-custom-fields.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
   </properties>
 </project>


### PR DESCRIPTION
RMB 33.1.1 is needed to fix the database memory fix RMB-863. mod-users is affected because it uses PgUtil.streamGet: https://github.com/folio-org/mod-users/blob/v18.1.0/src/main/java/org/folio/rest/impl/UsersAPI.java#L149

Also update folio-service-tools.version to 1.7.1 and
folio-custom-fields.version to 1.6.1
for Vert.x 4.1.4 support.

Also update joda-time from 2.10.6 to 2.10.12 and some test dependencies.