### PR TITLE
MODUSERS-272: Update RMB to 33.1.1 and Vert.x to 4.1.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 18.0.1
+
+* Database memory fix, update RMB to 33.1.1 and Vert.x to 4.1.4 (MODUSERS-272, MODUSERS-273)
+
 ## 18.0.0 2021-06-16
 
 * `embed_postgres` command line option is no longer supported (MODUSERS-255)

--- a/pom.xml
+++ b/pom.xml
@@ -38,16 +38,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -65,7 +55,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.10.6</version>
+      <version>2.10.12</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -522,13 +512,13 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <raml-module-builder.version>33.1.1</raml-module-builder.version>
+    <vertx.version>4.1.4</vertx.version>
     <generate_routing_context>/users</generate_routing_context>
-    <junit.version>5.5.2</junit.version>
-    <rest-assured.version>3.3.0</rest-assured.version>
-    <folio-service-tools.version>1.7.0</folio-service-tools.version>
-    <folio-custom-fields.version>1.6.0</folio-custom-fields.version>
+    <junit.version>5.8.1</junit.version>
+    <rest-assured.version>4.4.0</rest-assured.version>
+    <folio-service-tools.version>1.7.1</folio-service-tools.version>
+    <folio-custom-fields.version>1.6.1</folio-custom-fields.version>
     <jsoup.version>1.13.1</jsoup.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
   </properties>


### PR DESCRIPTION
This fixes the database memory bug:
https://issues.folio.org/browse/MODUSERS-272
https://issues.folio.org/browse/MODUSERS-273

The backport also updates folio-service-tools.version to 1.7.1 and
folio-custom-fields.version to 1.6.1 for Vert.x 4.1.4 support.

The backport also updates joda-time from 2.10.6 to 2.10.12 and some test
dependencies.

This is backporting the fix c1fab0a from master to b18.0.