### PR TITLE
MODUSERS-295: Upgrade to RMB 33.1.3 and Folio Service Tools 1.7.2 (Kiwi R3 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 18.1.2 IN-PROGRESS
+
+* Upgrade to RMB 33.1.3 and Folio Service Tools 1.7.2. (CVE-2021-44228) (MODUSERS-295)
+
 ## 18.1.1 2021-10-04
 
 * Update RMB to 33.1.1 and Vert.x to 4.1.4 (MODUSERS-272)

--- a/pom.xml
+++ b/pom.xml
@@ -507,12 +507,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>33.1.1</raml-module-builder.version>
+    <raml-module-builder.version>33.1.3</raml-module-builder.version>
     <vertx.version>4.1.4</vertx.version>
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.8.1</junit.version>
     <rest-assured.version>4.4.0</rest-assured.version>
-    <folio-service-tools.version>1.7.1</folio-service-tools.version>
+    <folio-service-tools.version>1.7.2</folio-service-tools.version>
     <folio-custom-fields.version>1.6.1</folio-custom-fields.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
   </properties>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODUSERS-295](https://issues.folio.org/browse/MODUSERS-295).