### PR TITLE
MODUSERS-305: Drop joda, replace by java.time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,6 @@
       <version>${folio-custom-fields.version}</version>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.10.12</version>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>


### PR DESCRIPTION
https://www.joda.org/joda-time/ suggests:

"Note that from Java SE 8 onwards, users are asked to migrate to java.time (JSR-310) - a core part of the JDK which replaces this project."

mod-users has a runtime dependency on joda, however, it uses joda in tests only.

Therefore this commit replaces joda by java.time in tests and completely removes joda dependency from pom.xml.