### PR TITLE
Remove user facets API MODUSERS-308

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 19.0.0 IN-PROGRESS
 
 * Made AddressTypeId field required for all user addresses (MODUSERS-212)
+* Removes users facets API (MODUSERS-308)
 * Provides `users 16.0`
 
 ## 18.3.0 2022-06-13

--- a/ramls/users.raml
+++ b/ramls/users.raml
@@ -18,7 +18,6 @@ traits:
   searchable: !include raml-util/traits/searchable.raml
   language: !include raml-util/traits/language.raml
   validate: !include raml-util/traits/validation.raml
-  facets: !include raml-util/traits/facets.raml
 
 resourceTypes:
   collection: !include raml-util/rtypes/collection.raml
@@ -37,8 +36,7 @@ resourceTypes:
     is: [
       searchable: {description: "", example: "active=true sortBy username"},
       orderable: {fieldsList: "field A, field B"},
-      pageable,
-      facets
+      pageable
     ]
     description: Return a list of users
   post:

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -2,6 +2,7 @@ package org.folio.rest.impl;
 
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
+import static java.util.Collections.emptyList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,8 +40,6 @@ import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
-import org.folio.rest.persist.facets.FacetField;
-import org.folio.rest.persist.facets.FacetManager;
 import org.folio.rest.tools.messages.MessageConsts;
 import org.folio.rest.tools.messages.Messages;
 import org.folio.rest.tools.utils.TenantTool;
@@ -55,6 +54,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.ext.web.RoutingContext;
 
 @Path("users")
@@ -132,7 +132,7 @@ public class UsersAPI implements Users {
   @Validate
   @Override
   public void getUsers(String query, String orderBy,
-      UsersGetOrder order, int offset, int limit, List<String> facets,
+      UsersGetOrder order, int offset, int limit,
       String lang, RoutingContext routingContext, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
@@ -142,9 +142,8 @@ public class UsersAPI implements Users {
       // note that orderBy is NOT used
       String tableName = getTableName(query);
       CQLWrapper cql = getCQL(query, limit, offset);
-      List<FacetField> facetList = FacetManager.convertFacetStrings2FacetFields(facets, "jsonb");
 
-      PgUtil.streamGet(tableName, User.class, cql, facetList, TABLE_NAME_USERS,
+      PgUtil.streamGet(tableName, User.class, cql, emptyList(), TABLE_NAME_USERS,
         routingContext, okapiHeaders, vertxContext);
     } catch (Exception e) {
       logger.error(query, e);

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -18,7 +18,6 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.support.Address;
 import org.folio.support.AddressType;
-import org.folio.support.Group;
 import org.folio.support.Personal;
 import org.folio.support.TagList;
 import org.folio.support.User;
@@ -442,38 +441,6 @@ class UsersAPIIT {
     final var activeUsers = usersClient.getUsers("active=true");
 
     assertThat(activeUsers.getTotalRecords(), is(2));
-  }
-
-  @Test
-  void canGetPatronGroupFacetsForUsers() {
-    final var alphaGroup = groupsClient.createGroup(Group.builder()
-      .group("Alpha group")
-      .build());
-
-    var zebraGroup = groupsClient.createGroup(Group.builder()
-      .group("Zebra group")
-      .build());
-
-    usersClient.createUser(User.builder()
-      .username("julia")
-      .patronGroup(alphaGroup.getId())
-      .build());
-
-    usersClient.createUser(User.builder()
-      .username("alex")
-      .patronGroup(zebraGroup.getId())
-      .build());
-
-    usersClient.createUser(User.builder()
-      .username("steven")
-      .patronGroup(zebraGroup.getId())
-      .build());
-
-    final var patronGroupFacets = usersClient.getPatronGroupFacets();
-
-    assertThat(patronGroupFacets.getTotalRecords(), is(3));
-    assertThat(patronGroupFacets.getFacetCount(zebraGroup.getId()), is(2));
-    assertThat(patronGroupFacets.getFacetCount(alphaGroup.getId()), is(1));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/UsersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPITest.java
@@ -81,7 +81,7 @@ class UsersAPITest {
 
   @Test
   void getUsersExceptionInCatch(VertxTestContext vtc) {
-    new UsersAPI().getUsers(null, null, null, 0, 0, null, null, null, null,
+    new UsersAPI().getUsers(null, null, null, 0, 0, null, null, null,
         vtc.succeeding(response -> vtc.verify( () -> {
           assertThat(response.getStatus(), is(500));
           vtc.completeNow();


### PR DESCRIPTION
## Purpose

[UIU-1562](https://issues.folio.org/browse/UIU-1562) removed the need for a count of users by patron group from the UI (as the current implementation was not fit for purpose).

In order to reduce the maintenance burden, the facets functionality can be removed from mod-users.

## Approach
* Remove the user facets API
* Increment major version of `users` interface (as this is an breaking change)
* Increment module major version (as this is an breaking change)
* Stop loading sample records during users API integration test (as tests no longer rely on them)