### PR TITLE
Improve groups integration test complexity MODUSERS-309

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,13 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>${rest-assured.version}</version>
+      <version>4.4.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -507,7 +513,6 @@
     <vertx.version>4.1.4</vertx.version>
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.8.1</junit.version>
-    <rest-assured.version>4.4.0</rest-assured.version>
     <folio-service-tools.version>1.7.2</folio-service-tools.version>
     <folio-custom-fields.version>1.6.1</folio-custom-fields.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -32,6 +32,7 @@ import org.folio.support.Users;
 import org.folio.support.ValidationErrors;
 import org.folio.support.http.GroupsClient;
 import org.folio.support.http.OkapiHeaders;
+import org.folio.support.http.UsersClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,7 @@ import lombok.SneakyThrows;
 class GroupIT {
   private static int port;
   private static GroupsClient groupsClient;
+  private static UsersClient usersClient;
 
   @BeforeAll
   @SneakyThrows
@@ -67,6 +69,9 @@ class GroupIT {
 
     RestAssured.port = port;
     groupsClient = new GroupsClient(new URI("http://localhost:" + port),
+      new OkapiHeaders("http://localhost:" + port, "diku", "diku"));
+
+    usersClient = new UsersClient(new URI("http://localhost:" + port),
       new OkapiHeaders("http://localhost:" + port, "diku", "diku"));
 
     TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku", WebClient.create(vertx));
@@ -87,7 +92,7 @@ class GroupIT {
 
   @BeforeEach
   public void beforeEach() {
-    deleteAllUsers();
+    usersClient.deleteAllUsers();
     groupsClient.deleteAllGroups();
   }
 
@@ -512,18 +517,5 @@ class GroupIT {
       .then()
       .statusCode(HTTP_OK)
       .extract().as(Users.class);
-  }
-
-  void deleteAllUsers() {
-    given()
-      .header("X-Okapi-Tenant", "diku")
-      .header("X-Okapi-Token", "")
-      .header("X-Okapi-Url", "http://localhost:" + port)
-      .accept("application/json, text/plain")
-      .when()
-      .param("query", "cql.allRecords=1")
-      .delete("/users")
-      .then()
-      .statusCode(204);
   }
 }

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
+import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -58,14 +59,14 @@ class GroupIT {
   private static GroupsClient groupsClient;
 
   @BeforeAll
+  @SneakyThrows
   public static void beforeAll(Vertx vertx, VertxTestContext context) {
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
 
     port = NetworkUtils.nextFreePort();
 
-    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     RestAssured.port = port;
-    groupsClient = new GroupsClient(
+    groupsClient = new GroupsClient(new URI("http://localhost:" + port),
       new OkapiHeaders("http://localhost:" + port, "diku", "diku"));
 
     TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku", WebClient.create(vertx));

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -206,7 +206,7 @@ class GroupIT {
 
     getGroup(UUID.randomUUID().toString(), HTTP_NOT_FOUND);
   }
-  
+
   @Test
   void canGetAllGroups() {
     createGroup(Group.builder()

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -27,7 +27,6 @@ import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.rest.utils.TenantInit;
 import org.folio.support.Group;
 import org.folio.support.User;
-import org.folio.support.Users;
 import org.folio.support.ValidationErrors;
 import org.folio.support.http.GroupsClient;
 import org.folio.support.http.OkapiHeaders;
@@ -293,7 +292,7 @@ class GroupIT {
       .username("julia")
       .patronGroup(group.getId()).build());
 
-    final var updatedUser = getUser(user.getId());
+    final var updatedUser = usersClient.getUser(user.getId());
 
     assertThat(updatedUser.getPatronGroup(), is(group.getId()));
   }
@@ -341,7 +340,7 @@ class GroupIT {
       .username("alex")
       .patronGroup(zebraGroup.getId()).build());
 
-    final var usersSortedByGroup = getUsers("cql.allRecords=1 sortBy " + sortClause);
+    final var usersSortedByGroup = usersClient.getUsers("cql.allRecords=1 sortBy " + sortClause);
 
     assertThat(usersSortedByGroup.getTotalRecords(), is(2));
     assertThat(usersSortedByGroup.getFirstUser().getUsername(), is(expectedFirstUsername));
@@ -365,7 +364,7 @@ class GroupIT {
       .username("alex")
       .patronGroup(zebraGroup.getId()).build());
 
-    final var usersFilteredByGroupName = getUsers("patronGroup.group=alpha");
+    final var usersFilteredByGroupName = usersClient.getUsers("patronGroup.group=alpha");
 
     assertThat(usersFilteredByGroupName.getTotalRecords(), is(1));
     assertThat(usersFilteredByGroupName.getFirstUser().getUsername(), is("julia"));
@@ -381,7 +380,7 @@ class GroupIT {
       .username("julia")
       .patronGroup(alphaGroup.getId()).build());
 
-    final var usersFilteredByGroupName = getUsers("patronGroup.group=missing");
+    final var usersFilteredByGroupName = usersClient.getUsers("patronGroup.group=missing");
 
     assertThat(usersFilteredByGroupName.getTotalRecords(), is(0));
   }
@@ -405,7 +404,7 @@ class GroupIT {
       .active(true)
       .build());
 
-    final var activeUsers = getUsers("active=true");
+    final var activeUsers = usersClient.getUsers("active=true");
 
     assertThat(activeUsers.getTotalRecords(), is(2));
   }
@@ -443,20 +442,6 @@ class GroupIT {
       is("User with this id already exists"));
   }
 
-  private User getUser(String id) {
-    return given()
-      .header("X-Okapi-Tenant", "diku")
-      .header("X-Okapi-Token", "")
-      .header("X-Okapi-Url", "http://localhost:" + port)
-      .accept("application/json, text/plain")
-      .when()
-      .get("/users/{id}", Map.of("id", id))
-      .then()
-      .statusCode(HTTP_OK)
-      .extract().as(User.class);
-  }
-
-  @SneakyThrows
   private void updateUser(@NonNull User user) {
     attemptToUpdateUser(user)
       .statusCode(HTTP_NO_CONTENT);
@@ -474,18 +459,5 @@ class GroupIT {
       .body(new ObjectMapper().writeValueAsString(user))
       .put("/users/{id}", Map.of("id", user.getId()))
       .then();
-  }
-
-  private Users getUsers(String query) {
-    return given()
-      .header("X-Okapi-Tenant", "diku")
-      .header("X-Okapi-Token", "")
-      .header("X-Okapi-Url", "http://localhost:" + port)
-      .accept("application/json, text/plain")
-      .when()
-      .get("/users?query=" + query)
-      .then()
-      .statusCode(HTTP_OK)
-      .extract().as(Users.class);
   }
 }

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -47,12 +47,10 @@ import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.rest.utils.ExpirationTool;
 import org.folio.rest.utils.TenantInit;
 import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
 
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
@@ -66,9 +64,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import lombok.SneakyThrows;
 
 @RunWith(VertxUnitRunner.class)
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class GroupIT {
-
   private final String userUrl = HTTP_LOCALHOST + RestITSupport.port() + "/users";
   private final String groupUrl = HTTP_LOCALHOST + RestITSupport.port() + "/groups";
 
@@ -92,7 +88,7 @@ public class GroupIT {
 
     Integer port = NetworkUtils.nextFreePort();
     RestITSupport.setUp(port);
-    TenantClient tenantClient = new TenantClient("http://localhost:" + Integer.toString(port), "diku", "diku");
+    TenantClient tenantClient = new TenantClient("http://localhost:" + port, "diku", "diku");
     DeploymentOptions options = new DeploymentOptions()
       .setConfig(new JsonObject().put("http.port", port));
 

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -116,7 +116,7 @@ class GroupIT {
 
     final var createdGroup = groupsClient.createGroup(group);
 
-    updateGroup(Group.builder()
+    groupsClient.updateGroup(Group.builder()
       .id(createdGroup.getId())
       .group("A new name")
       .desc("A new description")
@@ -435,21 +435,6 @@ class GroupIT {
 
     assertThat(errors.getErrors().get(0).getMessage(),
       is("User with this id already exists"));
-  }
-
-  @SneakyThrows
-  private void updateGroup(Group group) {
-    given()
-      .header("X-Okapi-Tenant", "diku")
-      .header("X-Okapi-Token", "")
-      .header("X-Okapi-Url", "http://localhost:" + port)
-      .contentType(JSON)
-      .accept("application/json, text/plain")
-      .when()
-      .body(new ObjectMapper().writeValueAsString(group))
-      .put("/groups/{id}", Map.of("id", group.getId()))
-      .then()
-      .statusCode(HTTP_NO_CONTENT);
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -99,7 +99,7 @@ class GroupIT {
       .expirationOffsetInDays(365)
       .build();
 
-    final var createdGroup = createGroup(group);
+    final var createdGroup = groupsClient.createGroup(group);
 
     assertThat(createdGroup.getId(), is(notNullValue()));
     assertThat(createdGroup.getGroup(), is("New Group"));
@@ -115,7 +115,7 @@ class GroupIT {
       .expirationOffsetInDays(365)
       .build();
 
-    final var createdGroup = createGroup(group);
+    final var createdGroup = groupsClient.createGroup(group);
 
     updateGroup(Group.builder()
       .id(createdGroup.getId())
@@ -132,7 +132,7 @@ class GroupIT {
 
   @Test
   void canDeleteAGroup() {
-    final var group = createGroup(Group.builder()
+    final var group = groupsClient.createGroup(Group.builder()
       .group("New Group")
       .build());
 
@@ -142,7 +142,7 @@ class GroupIT {
 
   @Test
   void cannotDeleteAGroupWithAssociatedUsers() {
-    final var group = createGroup(Group.builder()
+    final var group = groupsClient.createGroup(Group.builder()
       .group("New Group")
       .build());
 
@@ -162,7 +162,7 @@ class GroupIT {
 
   @Test
   void cannotDeleteAGroupThatDoesNotExist() {
-    createGroup(Group.builder()
+    groupsClient.createGroup(Group.builder()
       .group("New Group")
       .build());
 
@@ -173,11 +173,11 @@ class GroupIT {
 
   @Test
   void cannotCreateAGroupWithTheSameNameAsExistingGroup() {
-    createGroup(Group.builder()
+    groupsClient.createGroup(Group.builder()
       .group("New group")
       .build());
 
-    final var response = attemptToCreateGroup(Group.builder()
+    final var response = groupsClient.attemptToCreateGroup(Group.builder()
       .group("New group")
       .build());
 
@@ -191,7 +191,7 @@ class GroupIT {
 
   @Test
   void canGetAGroup() {
-    final var group = createGroup(Group.builder()
+    final var group = groupsClient.createGroup(Group.builder()
       .group("New group")
       .desc("Group description")
       .build());
@@ -204,7 +204,7 @@ class GroupIT {
 
   @Test
   void cannotGetAGroupThatDoesNotExist() {
-    createGroup(Group.builder()
+    groupsClient.createGroup(Group.builder()
       .group("New group")
       .build());
 
@@ -213,12 +213,12 @@ class GroupIT {
 
   @Test
   void canGetAllGroups() {
-    createGroup(Group.builder()
+    groupsClient.createGroup(Group.builder()
       .group("First new group")
       .desc("First group description")
       .build());
 
-    createGroup(Group.builder()
+    groupsClient.createGroup(Group.builder()
       .group("Second new group")
       .desc("Second group description")
       .build());
@@ -240,12 +240,12 @@ class GroupIT {
 
   @Test
   void canFindGroupByName() {
-    createGroup(Group.builder()
+    groupsClient.createGroup(Group.builder()
       .group("First new group")
       .desc("First group description")
       .build());
 
-    createGroup(Group.builder()
+    groupsClient.createGroup(Group.builder()
       .group("Second")
       .desc("Second group description")
       .build());
@@ -275,7 +275,7 @@ class GroupIT {
 
   @Test
   void canAssignAGroupToAUser() {
-    final var group = createGroup(Group.builder()
+    final var group = groupsClient.createGroup(Group.builder()
       .group("First new group")
       .build());
 
@@ -294,7 +294,7 @@ class GroupIT {
 
   @Test
   void cannotAssignGroupThatDoesNotExistToUser() {
-    final var group = createGroup(Group.builder()
+    final var group = groupsClient.createGroup(Group.builder()
       .group("First new group")
       .build());
 
@@ -319,11 +319,11 @@ class GroupIT {
   void canSortUsersByPatronGroupNameAscending(String sortClause,
     String expectedFirstUsername) {
 
-    final var alphaGroup = createGroup(Group.builder()
+    final var alphaGroup = groupsClient.createGroup(Group.builder()
       .group("Alpha group")
       .build());
 
-    var zebraGroup = createGroup(Group.builder()
+    var zebraGroup = groupsClient.createGroup(Group.builder()
       .group("Zebra group")
       .build());
 
@@ -343,11 +343,11 @@ class GroupIT {
 
   @Test
   void canFilterUsersByPatronGroup() {
-    final var alphaGroup = createGroup(Group.builder()
+    final var alphaGroup = groupsClient.createGroup(Group.builder()
       .group("Alpha group")
       .build());
 
-    var zebraGroup = createGroup(Group.builder()
+    var zebraGroup = groupsClient.createGroup(Group.builder()
       .group("Zebra group")
       .build());
 
@@ -367,7 +367,7 @@ class GroupIT {
 
   @Test
   void zeroUsersWhenFilteringUsersByPatronGroupThatDoesNotExist() {
-    final var alphaGroup = createGroup(Group.builder()
+    final var alphaGroup = groupsClient.createGroup(Group.builder()
       .group("Alpha group")
       .build());
 
@@ -435,27 +435,6 @@ class GroupIT {
 
     assertThat(errors.getErrors().get(0).getMessage(),
       is("User with this id already exists"));
-  }
-
-  @SneakyThrows
-  private Group createGroup(Group group) {
-    return attemptToCreateGroup(group)
-      .statusCode(HTTP_CREATED)
-      .extract().as(Group.class);
-  }
-
-  @SneakyThrows
-  private ValidatableResponse attemptToCreateGroup(Group group) {
-    return given()
-      .header("X-Okapi-Tenant", "diku")
-      .header("X-Okapi-Token", "")
-      .header("X-Okapi-Url", "http://localhost:" + port)
-      .contentType(JSON)
-      .accept("application/json, text/plain")
-      .when()
-      .body(new ObjectMapper().writeValueAsString(group))
-      .post("/groups")
-      .then();
   }
 
   private Group getGroup(String id) {

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -189,6 +189,29 @@ class GroupIT {
   }
 
   @Test
+  void canGetAGroup() {
+    final var group = createGroup(Group.builder()
+      .group("New group")
+      .desc("Group description")
+      .build());
+
+    final var foundGroup = getGroup(group.getId());
+
+    assertThat(foundGroup.getGroup(), is("New group"));
+    assertThat(foundGroup.getDesc(), is("Group description"));
+  }
+
+  @Test
+  void cannotGetAGroupThatDoesNotExist() {
+    createGroup(Group.builder()
+      .group("New group")
+      .desc("Group description")
+      .build());
+
+    getGroup(UUID.randomUUID().toString(), HTTP_NOT_FOUND);
+  }
+
+  @Test
   void canGetAllGroups() {
     createGroup(Group.builder()
       .group("First new group")
@@ -400,6 +423,7 @@ class GroupIT {
     assertThat(cqlResponse.body.getInteger("totalRecords"), is(1));
 
     /*
+
       try to add a duplicate group
      */
     CompletableFuture<Response> dupCF = send(groupUrl, POST,
@@ -408,16 +432,6 @@ class GroupIT {
     assertThat(dupResponse.code, is(422));
     log.info(dupResponse.body
       + "\nStatus - " + dupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
-
-    /*
-      get a group bad id
-     */
-    String getBadIDURL = groupUrl + "/3748ec8d-8dbc-4717-819d-87c839e6905e";
-    CompletableFuture<Response> getBadIDCF = send(getBadIDURL, GET, null, HTTPResponseHandlers.empty());
-    Response getBadIDResponse = getBadIDCF.get(5, SECONDS);
-    assertThat(getBadIDResponse.code, is(HTTP_NOT_FOUND));
-    log.info(getBadIDResponse.body
-      + "\nStatus - " + getBadIDResponse.code + " at " + System.currentTimeMillis() + " for " + getBadIDURL);
   }
 
   private CompletableFuture<Response> send(String url, HttpMethod method, String content,

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -18,6 +18,13 @@ import static org.folio.moduserstest.RestITSupport.get;
 import static org.folio.moduserstest.RestITSupport.post;
 import static org.folio.moduserstest.RestITSupport.put;
 import static org.folio.util.StringUtil.urlEncode;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -27,6 +34,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
@@ -51,11 +60,10 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.HttpResponse;
+import lombok.SneakyThrows;
 
 @RunWith(VertxUnitRunner.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -100,13 +108,14 @@ public class GroupIT {
   }
 
   @Test
-  public void test2Group(TestContext context) throws Exception {
+  @SneakyThrows
+  public void test2Group() {
     /*
       add a group
      */
     CompletableFuture<Response> addGroupCF = send(groupUrl, POST, fooGroupData, HTTPResponseHandlers.json());
     Response addGroupResponse = addGroupCF.get(5, SECONDS);
-    context.assertEquals(addGroupResponse.code, HTTP_CREATED);
+    assertThat(addGroupResponse.code, is(HTTP_CREATED));
     String groupID1 = addGroupResponse.body.getString("id");
     log.info(addGroupResponse.body
       + "\nStatus - " + addGroupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
@@ -117,7 +126,7 @@ public class GroupIT {
     String updateGroupURL = groupUrl + "/" + groupID1;
     CompletableFuture<Response> updateGroupCF = send(updateGroupURL, PUT, barGroupData, HTTPResponseHandlers.empty());
     Response updateGroupResponse = updateGroupCF.get(5, SECONDS);
-    context.assertEquals(updateGroupResponse.code, HTTP_NO_CONTENT);
+    assertThat(updateGroupResponse.code, is(HTTP_NO_CONTENT));
     log.info(updateGroupResponse.body
       + "\nStatus - " + updateGroupResponse.code + " at " + System.currentTimeMillis() + " for " + updateGroupURL);
 
@@ -127,7 +136,7 @@ public class GroupIT {
     String deleteCleanURL = groupUrl + "/" + groupID1;
     CompletableFuture<Response> deleteCleanCF = send(deleteCleanURL, DELETE, null, HTTPResponseHandlers.empty());
     Response deleteCleanResponse = deleteCleanCF.get(5, SECONDS);
-    context.assertEquals(deleteCleanResponse.code, HTTP_NO_CONTENT);
+    assertThat(deleteCleanResponse.code, is(HTTP_NO_CONTENT));
     log.info(deleteCleanResponse.body
       + "\nStatus - " + deleteCleanResponse.code + " at " + System.currentTimeMillis() + " for " + deleteCleanURL);
 
@@ -136,7 +145,7 @@ public class GroupIT {
      */
     CompletableFuture<Response> addNewGroupCF = send(groupUrl, POST, fooGroupData, HTTPResponseHandlers.json());
     Response addNewGroupResponse = addNewGroupCF.get(5, SECONDS);
-    context.assertEquals(addNewGroupResponse.code, HTTP_CREATED);
+    assertThat(addNewGroupResponse.code, is(HTTP_CREATED));
     groupID1 = addNewGroupResponse.body.getString("id");
     log.info(addNewGroupResponse.body
       + "\nStatus - " + addNewGroupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
@@ -148,7 +157,7 @@ public class GroupIT {
     CompletableFuture<Response> addUserCF = send(addUserURL, POST, createUser(null, "jhandley", groupID1).encode(),
       HTTPResponseHandlers.json());
     Response addUserResponse = addUserCF.get(5, SECONDS);
-    context.assertEquals(addUserResponse.code, HTTP_CREATED);
+    assertThat(addUserResponse.code, is(HTTP_CREATED));
     String userID = addUserResponse.body.getString("id");
     log.info(addUserResponse.body
       + "\nStatus - " + addUserResponse.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
@@ -159,7 +168,7 @@ public class GroupIT {
     CompletableFuture<Response> addUserCF2 = send(addUserURL, POST, createUser(null, "jhandley", groupID1).encode(),
       HTTPResponseHandlers.json());
     Response addUserResponse2 = addUserCF2.get(5, SECONDS);
-    context.assertEquals(addUserResponse2.code, 422);
+    assertThat(addUserResponse2.code, is(422));
     log.info(addUserResponse2.body
       + "\nStatus - " + addUserResponse2.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
 
@@ -169,7 +178,7 @@ public class GroupIT {
     CompletableFuture<Response> addUserCF3 = send(addUserURL, POST, createUser(userID, "jhandley", groupID1).encode(),
       HTTPResponseHandlers.json());
     Response addUserResponse3 = addUserCF3.get(5, SECONDS);
-    context.assertEquals(addUserResponse3.code, 422);
+    assertThat(addUserResponse3.code, is(422));
     log.info(addUserResponse3.body
       + "\nStatus - " + addUserResponse3.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
 
@@ -180,7 +189,7 @@ public class GroupIT {
       createUser(null, "jhandley2nd", "10c19698-313b-46fc-8d4b-2d00c6958f5d").encode(),
       HTTPResponseHandlers.empty());
     Response addUserResponse4 = addUserCF4.get(5, SECONDS);
-    context.assertEquals(addUserResponse4.code, HTTP_BAD_REQUEST);
+    assertThat(addUserResponse4.code, is(HTTP_BAD_REQUEST));
     log.info(addUserResponse4.body
       + "\nStatus - " + addUserResponse4.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
 
@@ -190,7 +199,7 @@ public class GroupIT {
     CompletableFuture<Response> addUserCF4a = send(addUserURL, POST, createUser(null, "jhandley2nd", "invalid-uuid").encode(),
       HTTPResponseHandlers.empty());
     Response addUserResponse4a = addUserCF4a.get(5, SECONDS);
-    context.assertEquals(addUserResponse4a.code, HTTP_UNPROCESSABLE_ENTITY.toInt());
+    assertThat(addUserResponse4a.code, is(HTTP_UNPROCESSABLE_ENTITY.toInt()));
     log.info(addUserResponse4a.body
       + "\nStatus - " + addUserResponse4a.code + " at " + System.currentTimeMillis() + " for " + addUserURL);
 
@@ -200,7 +209,7 @@ public class GroupIT {
     CompletableFuture<Response> updateUserCF = send(addUserURL + "/" + userID, PUT, createUser(userID, "jhandley2nd",
       "20c19698-313b-46fc-8d4b-2d00c6958f5d").encode(), HTTPResponseHandlers.empty());
     Response updateUserResponse = updateUserCF.get(5, SECONDS);
-    context.assertEquals(updateUserResponse.code, HTTP_BAD_REQUEST);
+    assertThat(updateUserResponse.code, is(HTTP_BAD_REQUEST));
     log.info(updateUserResponse.body
       + "\nStatus - " + updateUserResponse.code + " at " + System.currentTimeMillis() + " for " + addUserURL + "/" + userID);
 
@@ -211,7 +220,7 @@ public class GroupIT {
       createUser(userID, "jhandley2nd", groupID1).encode(),
       HTTPResponseHandlers.empty());
     Response updateUser2Response = updateUser2CF.get(5, SECONDS);
-    context.assertEquals(updateUser2Response.code, HTTP_NO_CONTENT);
+    assertThat(updateUser2Response.code, is(HTTP_NO_CONTENT));
     log.info(updateUser2Response.body
       + "\nStatus - " + updateUser2Response.code + " at " + System.currentTimeMillis() + " for " + addUserURL + "/" + userID);
 
@@ -222,21 +231,21 @@ public class GroupIT {
     CompletableFuture<Response> getUsersInGroupCF = send(getUsersInGroupURL, GET, null,
       HTTPResponseHandlers.json());
     Response getUsersInGroupResponse = getUsersInGroupCF.get(5, SECONDS);
-    context.assertEquals(getUsersInGroupResponse.code, HTTP_OK);
+    assertThat(getUsersInGroupResponse.code, is(HTTP_OK));
     log.info(getUsersInGroupResponse.body
       + "\nStatus - " + getUsersInGroupResponse.code + " at " + System.currentTimeMillis() + " for "
       + getUsersInGroupURL);
-    context.assertTrue(isSizeMatch(getUsersInGroupResponse, 1));
+    assertThat(getUsersInGroupResponse.body.getInteger("totalRecords"), is(1));
 
     /*
       get all groups in groups table
      */
     CompletableFuture<Response> getAllGroupCF = send(groupUrl, GET, null, HTTPResponseHandlers.json());
     Response getAllGroupResponse = getAllGroupCF.get(5, SECONDS);
-    context.assertEquals(getAllGroupResponse.code, HTTP_OK);
+    assertThat(getAllGroupResponse.code, is(HTTP_OK));
     log.info(getAllGroupResponse.body
       + "\nStatus - " + getAllGroupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
-    context.assertTrue(isSizeMatch(getAllGroupResponse, 5)); // 4 in reference + 1 in test
+    assertThat(getAllGroupResponse.body.getInteger("totalRecords"), is(5)); // 4 in reference + 1 in test
 
     /*
       try to get via cql
@@ -244,10 +253,10 @@ public class GroupIT {
     String cqlURL = groupUrl + "?query=group==librarianFOO";
     CompletableFuture<Response> cqlCF = send(cqlURL, GET, null, HTTPResponseHandlers.json());
     Response cqlResponse = cqlCF.get(5, SECONDS);
-    context.assertEquals(cqlResponse.code, HTTP_OK);
+    assertThat(cqlResponse.code, is(HTTP_OK));
     log.info(cqlResponse.body
       + "\nStatus - " + cqlResponse.code + " at " + System.currentTimeMillis() + " for " + cqlURL);
-    context.assertTrue(isSizeMatch(cqlResponse, 1));
+    assertThat(cqlResponse.body.getInteger("totalRecords"), is(1));
 
     /*
       delete a group - should fail as there is a user associated with the group
@@ -255,7 +264,7 @@ public class GroupIT {
     String delete1URL = groupUrl + "/" + groupID1;
     CompletableFuture<Response> delete1CF = send(delete1URL, DELETE, null, HTTPResponseHandlers.empty());
     Response delete1Response = delete1CF.get(5, SECONDS);
-    context.assertEquals(delete1Response.code, HTTP_BAD_REQUEST);
+    assertThat(delete1Response.code, is(HTTP_BAD_REQUEST));
     log.info(delete1Response.body
       + "\nStatus - " + delete1Response.code + " at " + System.currentTimeMillis() + " for " + delete1URL);
 
@@ -265,7 +274,7 @@ public class GroupIT {
     String deleteNEGURL = groupUrl + "/a492ffd2-b848-48bf-b716-1a645822279e";
     CompletableFuture<Response> deleteNEGCF = send(deleteNEGURL, DELETE, null, HTTPResponseHandlers.empty());
     Response deleteNEGResponse = deleteNEGCF.get(5, SECONDS);
-    context.assertEquals(deleteNEGResponse.code, HTTP_NOT_FOUND);
+    assertThat(deleteNEGResponse.code, is(HTTP_NOT_FOUND));
     log.info(deleteNEGResponse.body
       + "\nStatus - " + deleteNEGResponse.code + " at " + System.currentTimeMillis() + " for " + deleteNEGURL);
 
@@ -274,7 +283,7 @@ public class GroupIT {
      */
     CompletableFuture<Response> dupCF = send(groupUrl, POST, fooGroupData, HTTPResponseHandlers.json());
     Response dupResponse = dupCF.get(5, SECONDS);
-    context.assertEquals(dupResponse.code, 422);
+    assertThat(dupResponse.code, is(422));
     log.info(dupResponse.body
       + "\nStatus - " + dupResponse.code + " at " + System.currentTimeMillis() + " for " + groupUrl);
 
@@ -284,10 +293,10 @@ public class GroupIT {
     String getSpecGroupURL = groupUrl + "/" + groupID1;
     CompletableFuture<Response> getSpecGroupCF = send(getSpecGroupURL, GET, null, HTTPResponseHandlers.json());
     Response getSpecGroupResponse = getSpecGroupCF.get(5, SECONDS);
-    context.assertEquals(getSpecGroupResponse.code, HTTP_OK);
+    assertThat(getSpecGroupResponse.code, is(HTTP_OK));
     log.info(getSpecGroupResponse.body
       + "\nStatus - " + getSpecGroupResponse.code + " at " + System.currentTimeMillis() + " for " + getSpecGroupURL);
-    context.assertTrue("librarianFOO".equals(getSpecGroupResponse.body.getString("group")));
+    assertThat(getSpecGroupResponse.body.getString("group"), is("librarianFOO"));
 
     /*
       get a group bad id
@@ -295,7 +304,7 @@ public class GroupIT {
     String getBadIDURL = groupUrl + "/3748ec8d-8dbc-4717-819d-87c839e6905e";
     CompletableFuture<Response> getBadIDCF = send(getBadIDURL, GET, null, HTTPResponseHandlers.empty());
     Response getBadIDResponse = getBadIDCF.get(5, SECONDS);
-    context.assertEquals(getBadIDResponse.code, HTTP_NOT_FOUND);
+    assertThat(getBadIDResponse.code, is(HTTP_NOT_FOUND));
     log.info(getBadIDResponse.body
       + "\nStatus - " + getBadIDResponse.code + " at " + System.currentTimeMillis() + " for " + getBadIDURL);
 
@@ -305,7 +314,7 @@ public class GroupIT {
     String delete = groupUrl + "/" + groupID1;
     CompletableFuture<Response> deleteCF = send(delete, DELETE, null, HTTPResponseHandlers.empty());
     Response deleteResponse = deleteCF.get(5, SECONDS);
-    context.assertEquals(deleteResponse.code, HTTP_BAD_REQUEST);
+    assertThat(deleteResponse.code, is(HTTP_BAD_REQUEST));
     log.info(deleteResponse.body
       + "\nStatus - " + deleteResponse.code + " at " + System.currentTimeMillis() + " for " + delete);
 
@@ -330,7 +339,7 @@ public class GroupIT {
       log.info(addExpiredUserResponse.body
         + "\nStatus - " + addExpiredUserResponse.code + " at "
         + System.currentTimeMillis() + " for " + addUserURL + " (addExpiredUser)");
-      context.assertEquals(addExpiredUserResponse.code, 201);
+      assertThat(addExpiredUserResponse.code, is(201));
       CompletableFuture<Void> getExpirationCF = new CompletableFuture<Void>();
       ExpirationTool.doExpirationForTenant(RestITSupport.vertx(), "diku")
         .onComplete(res -> getExpirationCF.complete(null));
@@ -339,27 +348,27 @@ public class GroupIT {
       CompletableFuture<Response> getExpiredUserCF = send(addUserURL + "/" + expiredUserId.toString(), GET, null,
         HTTPResponseHandlers.json());
       Response getExpiredUserResponse = getExpiredUserCF.get(5, SECONDS);
-      context.assertEquals(getExpiredUserResponse.body.getBoolean("active"), false);
+      assertThat(getExpiredUserResponse.body.getBoolean("active"), is(false));
     }
 
     CompletableFuture<Response> postGroupCF = send(groupUrl, POST, barGroupData, HTTPResponseHandlers.json());
     Response postGroupResponse = postGroupCF.get(5, SECONDS);
-    context.assertEquals(postGroupResponse.code, HTTP_CREATED);
+    assertThat(postGroupResponse.code, is(HTTP_CREATED));
     String barGroupId = postGroupResponse.body.getString("id");
-    context.assertNotNull(barGroupId);
+    assertThat(barGroupId, is(notNullValue()));
 
     int inc = 0;
     addUserCF = send(userUrl, POST, createUser(null, "jhandley" + inc++, barGroupId).encode(),
       HTTPResponseHandlers.json());
     addUserResponse = addUserCF.get(5, SECONDS);
-    context.assertEquals(addUserResponse.code, HTTP_CREATED);
+    assertThat(addUserResponse.code, is(HTTP_CREATED));
     log.info(addUserResponse.body
       + "\nStatus - " + addUserResponse.code + " at " + System.currentTimeMillis() + " for " + userUrl);
 
     addUserCF2 = send(userUrl, POST, createUser(null, "jhandley" + inc++, barGroupId).encode(),
       HTTPResponseHandlers.json());
     addUserResponse2 = addUserCF2.get(5, SECONDS);
-    context.assertEquals(addUserResponse2.code, HTTP_CREATED);
+    assertThat(addUserResponse2.code, is(HTTP_CREATED));
     log.info(addUserResponse2.body
       + "\nStatus - " + addUserResponse2.code + " at " + System.currentTimeMillis() + " for " + userUrl);
 
@@ -388,38 +397,40 @@ public class GroupIT {
       CompletableFuture<Response> cf = send(cqlURL, GET, null, HTTPResponseHandlers.json());
 
       cqlResponse = cf.get(5, SECONDS);
-      context.assertEquals(cqlResponse.code, HTTP_OK);
+      assertThat(cqlResponse.code, is(HTTP_OK));
       log.info(cqlResponse.body
         + "\nStatus - " + cqlResponse.code + " at " + System.currentTimeMillis() + " for " + cqlURL + " (url" + (i) + ") : " + cqlResponse.body.toString());
       //requests should usually have 3 or 4 results
       switch (i) {
         case 5:
-          context.assertEquals(1, cqlResponse.body.getInteger("totalRecords"));
+          assertThat(cqlResponse.body.getInteger("totalRecords"), is(1));
           break;
         case 7:
-          context.assertEquals(0, cqlResponse.body.getInteger("totalRecords"));
+          assertThat(cqlResponse.body.getInteger("totalRecords"), is(0));
           break;
         case 6:
-          context.assertTrue(cqlResponse.body.getInteger("totalRecords") > 2);
+          assertThat(cqlResponse.body.getInteger("totalRecords"), is(greaterThan(2)));
           break;
         case 1:
-          context.assertEquals(4, cqlResponse.body.getInteger("totalRecords"));
-          context.assertEquals("jhandley2nd", cqlResponse.body.getJsonArray("users").getJsonObject(0).getString("username"));
+          assertThat(cqlResponse.body.getInteger("totalRecords"), is(4));
+          assertThat(cqlResponse.body.getJsonArray("users").getJsonObject(0).getString("username"), is("jhandley2nd"));
           break;
         case 2:
-          context.assertEquals(4, cqlResponse.body.getInteger("totalRecords"));
-          context.assertNotEquals("jhandley2nd", cqlResponse.body.getJsonArray("users").getJsonObject(0).getString("username"));
+          assertThat(cqlResponse.body.getInteger("totalRecords"), is(4));
+          assertThat(cqlResponse.body.getJsonArray("users").getJsonObject(0).getString("username"), is("jhandley0"));
           break;
         case 4:
-          context.assertTrue(((String) (new JsonPathParser(cqlResponse.body).getValueAt("users[0].personal.lastName"))).startsWith("Triangle"));
+          assertThat(((String) (new JsonPathParser(cqlResponse.body).getValueAt("users[0].personal.lastName"))), startsWith("Triangle"));
           break;
         case 0:
           //Baseline test
           int totalRecords = cqlResponse.body.getInteger("totalRecords");
-          context.assertEquals(4, totalRecords);
+          assertThat(totalRecords, is(4));
           break;
         default:
-          context.assertInRange(2, cqlResponse.body.getInteger("totalRecords"), 2);
+          // This mimics the previous range assertion, should be replaced with more specific assertions
+          assertThat(cqlResponse.body.getInteger("totalRecords"), is(greaterThanOrEqualTo(0)));
+          assertThat(cqlResponse.body.getInteger("totalRecords"), is(lessThanOrEqualTo(4)));
           break;
       }
     }
@@ -472,18 +483,12 @@ public class GroupIT {
     return user;
   }
 
-  private boolean isSizeMatch(Response r, int size) {
-    return r.body.getInteger("totalRecords") == size;
-  }
-
   private static class Response {
-
     int code;
     JsonObject body;
   }
 
   private static class HTTPResponseHandlers {
-
     static Function<HttpResponse<Buffer>, Response> empty() {
       return response -> {
         Response result = new Response();
@@ -501,5 +506,4 @@ public class GroupIT {
       };
     }
   }
-
 }

--- a/src/test/java/org/folio/support/Address.java
+++ b/src/test/java/org/folio/support/Address.java
@@ -1,5 +1,7 @@
 package org.folio.support;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
@@ -7,6 +9,7 @@ import lombok.extern.jackson.Jacksonized;
 @Value
 @Builder
 @Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Address {
   String addressTypeId;
 }

--- a/src/test/java/org/folio/support/Group.java
+++ b/src/test/java/org/folio/support/Group.java
@@ -1,0 +1,14 @@
+package org.folio.support;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class Group {
+  String group;
+  String desc;
+  Integer expirationOffsetInDays;
+}

--- a/src/test/java/org/folio/support/Group.java
+++ b/src/test/java/org/folio/support/Group.java
@@ -1,5 +1,7 @@
 package org.folio.support;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
@@ -7,7 +9,9 @@ import lombok.extern.jackson.Jacksonized;
 @Value
 @Builder
 @Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Group {
+  String id;
   String group;
   String desc;
   Integer expirationOffsetInDays;

--- a/src/test/java/org/folio/support/Groups.java
+++ b/src/test/java/org/folio/support/Groups.java
@@ -1,0 +1,25 @@
+package org.folio.support;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Groups {
+  List<Group> usergroups;
+  int totalRecords;
+
+  public Group getGroupByName(String name) {
+    return usergroups.stream()
+      .filter(group -> Objects.equals(group.getGroup(), name))
+      .findFirst().orElse(null);
+  }
+}

--- a/src/test/java/org/folio/support/User.java
+++ b/src/test/java/org/folio/support/User.java
@@ -1,14 +1,19 @@
 package org.folio.support;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
-
 @Value
 @Builder
 @Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class User {
+  String id;
   String username;
+  Boolean active;
   Personal personal;
+  String patronGroup;
 }

--- a/src/test/java/org/folio/support/Users.java
+++ b/src/test/java/org/folio/support/Users.java
@@ -12,8 +12,6 @@ import lombok.extern.jackson.Jacksonized;
 @Builder
 @Jacksonized
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Personal {
-  String lastName;
-  String firstName;
-  List<Address> addresses;
-}
+public class Users {
+  List<User> users;
+  int totalRecords;}

--- a/src/test/java/org/folio/support/Users.java
+++ b/src/test/java/org/folio/support/Users.java
@@ -14,4 +14,9 @@ import lombok.extern.jackson.Jacksonized;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Users {
   List<User> users;
-  int totalRecords;}
+  int totalRecords;
+
+  public User getFirstUser() {
+    return getUsers().get(0);
+  }
+}

--- a/src/test/java/org/folio/support/ValidationError.java
+++ b/src/test/java/org/folio/support/ValidationError.java
@@ -1,0 +1,15 @@
+package org.folio.support;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ValidationError {
+  String message;
+}

--- a/src/test/java/org/folio/support/ValidationErrors.java
+++ b/src/test/java/org/folio/support/ValidationErrors.java
@@ -1,0 +1,17 @@
+package org.folio.support;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ValidationErrors {
+  List<ValidationError> errors;
+}

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -109,4 +109,19 @@ public class GroupsClient {
       .statusCode(HTTP_OK)
       .extract().as(Groups.class);
   }
+
+  @SneakyThrows
+  public void updateGroup(@NonNull Group group) {
+    given()
+      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .header("X-Okapi-Token", defaultHeaders.getToken())
+      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .accept("application/json, text/plain")
+      .contentType(JSON)
+      .when()
+      .body(new ObjectMapper().writeValueAsString(group))
+      .put("/groups/{id}", Map.of("id", group.getId()))
+      .then()
+      .statusCode(HTTP_NO_CONTENT);
+  }
 }

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -78,4 +78,35 @@ public class GroupsClient {
 
     groups.getUsergroups().forEach(group -> deleteGroup(group.getId()));
   }
+
+  public Group getGroup(String id) {
+    return attemptToGetGroup(id)
+      .statusCode(HTTP_OK)
+      .extract().as(Group.class);
+  }
+
+  public ValidatableResponse attemptToGetGroup(String id) {
+    return given()
+      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .header("X-Okapi-Token", defaultHeaders.getToken())
+      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .accept("application/json, text/plain")
+      .when()
+      .get("/groups/{id}", Map.of("id", id))
+      .then();
+  }
+
+  public Groups findGroups(String cqlQuery) {
+    return given()
+      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .header("X-Okapi-Token", defaultHeaders.getToken())
+      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .accept("application/json, text/plain")
+      .when()
+      .queryParam("query", cqlQuery)
+      .get("/groups")
+      .then()
+      .statusCode(HTTP_OK)
+      .extract().as(Groups.class);
+  }
 }

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -1,20 +1,47 @@
 package org.folio.support.http;
 
 import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.util.Map;
 
+import org.folio.support.Group;
 import org.folio.support.Groups;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.restassured.response.ValidatableResponse;
+import lombok.NonNull;
+import lombok.SneakyThrows;
 
 public class GroupsClient {
   private final OkapiHeaders defaultHeaders;
 
   public GroupsClient(OkapiHeaders defaultHeaders) {
     this.defaultHeaders = defaultHeaders;
+  }
+
+  public Group createGroup(@NonNull Group group) {
+    return attemptToCreateGroup(group)
+      .statusCode(HTTP_CREATED)
+      .extract().as(Group.class);
+  }
+
+  @SneakyThrows
+  public ValidatableResponse attemptToCreateGroup(@NonNull Group group) {
+    return given()
+      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .header("X-Okapi-Token", defaultHeaders.getToken())
+      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .accept("application/json, text/plain")
+      .contentType(JSON)
+      .when()
+      .body(new ObjectMapper().writeValueAsString(group))
+      .post("/groups")
+      .then();
   }
 
   public Groups getAllGroups() {

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -1,0 +1,54 @@
+package org.folio.support.http;
+
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static java.net.HttpURLConnection.HTTP_OK;
+
+import java.util.Map;
+
+import org.folio.support.Groups;
+
+import io.restassured.response.ValidatableResponse;
+
+public class GroupsClient {
+  private final OkapiHeaders defaultHeaders;
+
+  public GroupsClient(OkapiHeaders defaultHeaders) {
+    this.defaultHeaders = defaultHeaders;
+  }
+
+  public Groups getAllGroups() {
+    return given()
+      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .header("X-Okapi-Token", defaultHeaders.getToken())
+      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .accept("application/json, text/plain")
+      .when()
+      .get("/groups")
+      .then()
+      .statusCode(HTTP_OK)
+      .extract().as(Groups.class);
+  }
+
+  public void deleteGroup(String id) {
+    attemptToDeleteGroup(id)
+      .statusCode(HTTP_NO_CONTENT);
+  }
+
+  public ValidatableResponse attemptToDeleteGroup(String id) {
+    return given()
+      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .header("X-Okapi-Token", defaultHeaders.getToken())
+      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .accept("application/json, text/plain")
+      .when()
+      .delete("/groups/{id}", Map.of("id", id))
+      .then();
+  }
+
+  public void deleteAllGroups() {
+    final var groups = getAllGroups();
+
+    groups.getUsergroups().forEach(group -> deleteGroup(group.getId()));
+  }
+}

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -6,29 +6,37 @@ import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 
+import java.net.URI;
 import java.util.Map;
 
 import org.folio.support.Group;
 import org.folio.support.Groups;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.config.LogConfig;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 
 public class GroupsClient {
   private final RequestSpecification requestSpecification;
+  private final RestAssuredConfig config;
 
-  public GroupsClient(OkapiHeaders defaultHeaders) {
+  public GroupsClient(URI baseUri, OkapiHeaders defaultHeaders) {
     requestSpecification = new RequestSpecBuilder()
+      .setBaseUri(baseUri)
       .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
       .addHeader("X-Okapi-Token", defaultHeaders.getToken())
       .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
       .setAccept("application/json, text/plain")
       .build();
+
+    config = RestAssuredConfig.newConfig()
+      .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2))
+      .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails());
   }
 
   public Group createGroup(@NonNull Group group) {
@@ -37,19 +45,20 @@ public class GroupsClient {
       .extract().as(Group.class);
   }
 
-  @SneakyThrows
   public ValidatableResponse attemptToCreateGroup(@NonNull Group group) {
     return given()
+      .config(config)
       .spec(requestSpecification)
       .contentType(JSON)
       .when()
-      .body(new ObjectMapper().writeValueAsString(group))
+      .body(group)
       .post("/groups")
       .then();
   }
 
   public Groups getAllGroups() {
     return given()
+      .config(config)
       .spec(requestSpecification)
       .when()
       .get("/groups")
@@ -65,6 +74,7 @@ public class GroupsClient {
 
   public ValidatableResponse attemptToDeleteGroup(String id) {
     return given()
+      .config(config)
       .spec(requestSpecification)
       .when()
       .delete("/groups/{id}", Map.of("id", id))
@@ -85,6 +95,7 @@ public class GroupsClient {
 
   public ValidatableResponse attemptToGetGroup(String id) {
     return given()
+      .config(config)
       .spec(requestSpecification)
       .when()
       .get("/groups/{id}", Map.of("id", id))
@@ -93,6 +104,7 @@ public class GroupsClient {
 
   public Groups findGroups(String cqlQuery) {
     return given()
+      .config(config)
       .spec(requestSpecification)
       .when()
       .queryParam("query", cqlQuery)
@@ -102,13 +114,12 @@ public class GroupsClient {
       .extract().as(Groups.class);
   }
 
-  @SneakyThrows
   public void updateGroup(@NonNull Group group) {
     given()
       .spec(requestSpecification)
       .contentType(JSON)
       .when()
-      .body(new ObjectMapper().writeValueAsString(group))
+      .body(group)
       .put("/groups/{id}", Map.of("id", group.getId()))
       .then()
       .statusCode(HTTP_NO_CONTENT);

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -13,15 +13,22 @@ import org.folio.support.Groups;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 
 public class GroupsClient {
-  private final OkapiHeaders defaultHeaders;
+  private final RequestSpecification requestSpecification;
 
   public GroupsClient(OkapiHeaders defaultHeaders) {
-    this.defaultHeaders = defaultHeaders;
+    requestSpecification = new RequestSpecBuilder()
+      .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .addHeader("X-Okapi-Token", defaultHeaders.getToken())
+      .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .setAccept("application/json, text/plain")
+      .build();
   }
 
   public Group createGroup(@NonNull Group group) {
@@ -33,10 +40,7 @@ public class GroupsClient {
   @SneakyThrows
   public ValidatableResponse attemptToCreateGroup(@NonNull Group group) {
     return given()
-      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .header("X-Okapi-Token", defaultHeaders.getToken())
-      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .accept("application/json, text/plain")
+      .spec(requestSpecification)
       .contentType(JSON)
       .when()
       .body(new ObjectMapper().writeValueAsString(group))
@@ -46,10 +50,7 @@ public class GroupsClient {
 
   public Groups getAllGroups() {
     return given()
-      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .header("X-Okapi-Token", defaultHeaders.getToken())
-      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .accept("application/json, text/plain")
+      .spec(requestSpecification)
       .when()
       .get("/groups")
       .then()
@@ -64,10 +65,7 @@ public class GroupsClient {
 
   public ValidatableResponse attemptToDeleteGroup(String id) {
     return given()
-      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .header("X-Okapi-Token", defaultHeaders.getToken())
-      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .accept("application/json, text/plain")
+      .spec(requestSpecification)
       .when()
       .delete("/groups/{id}", Map.of("id", id))
       .then();
@@ -87,10 +85,7 @@ public class GroupsClient {
 
   public ValidatableResponse attemptToGetGroup(String id) {
     return given()
-      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .header("X-Okapi-Token", defaultHeaders.getToken())
-      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .accept("application/json, text/plain")
+      .spec(requestSpecification)
       .when()
       .get("/groups/{id}", Map.of("id", id))
       .then();
@@ -98,10 +93,7 @@ public class GroupsClient {
 
   public Groups findGroups(String cqlQuery) {
     return given()
-      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .header("X-Okapi-Token", defaultHeaders.getToken())
-      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .accept("application/json, text/plain")
+      .spec(requestSpecification)
       .when()
       .queryParam("query", cqlQuery)
       .get("/groups")
@@ -113,10 +105,7 @@ public class GroupsClient {
   @SneakyThrows
   public void updateGroup(@NonNull Group group) {
     given()
-      .header("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .header("X-Okapi-Token", defaultHeaders.getToken())
-      .header("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .accept("application/json, text/plain")
+      .spec(requestSpecification)
       .contentType(JSON)
       .when()
       .body(new ObjectMapper().writeValueAsString(group))

--- a/src/test/java/org/folio/support/http/OkapiHeaders.java
+++ b/src/test/java/org/folio/support/http/OkapiHeaders.java
@@ -1,0 +1,11 @@
+package org.folio.support.http;
+
+import lombok.Value;
+
+@Value
+public
+class OkapiHeaders {
+  String okapiUrl;
+  String tenantId;
+  String token;
+}

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -1,0 +1,41 @@
+package org.folio.support.http;
+
+import static io.restassured.RestAssured.given;
+
+import java.net.URI;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.config.LogConfig;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.mapper.ObjectMapperType;
+import io.restassured.specification.RequestSpecification;
+
+public class UsersClient {
+  private final RequestSpecification requestSpecification;
+  private final RestAssuredConfig config;
+  public UsersClient(URI baseUri, OkapiHeaders defaultHeaders) {
+    requestSpecification = new RequestSpecBuilder()
+      .setBaseUri(baseUri)
+      .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .addHeader("X-Okapi-Token", defaultHeaders.getToken())
+      .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .setAccept("application/json, text/plain")
+      .build();
+
+    config = RestAssuredConfig.newConfig()
+      .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2))
+      .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails());
+  }
+
+  public void deleteAllUsers() {
+    given()
+      .config(config)
+      .spec(requestSpecification)
+      .when()
+      .param("query", "cql.allRecords=1")
+      .delete("/users")
+      .then()
+      .statusCode(204);
+  }
+}

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -3,10 +3,13 @@ package org.folio.support.http;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.net.URI;
+import java.util.Map;
 
 import org.folio.support.User;
+import org.folio.support.Users;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.LogConfig;
@@ -49,6 +52,28 @@ public class UsersClient {
       .body(user)
       .post("/users")
       .then();
+  }
+
+  public User getUser(String id) {
+    return given()
+      .config(config)
+      .spec(requestSpecification)
+      .when()
+      .get("/users/{id}", Map.of("id", id))
+      .then()
+      .statusCode(HTTP_OK)
+      .extract().as(User.class);
+  }
+
+  public Users getUsers(String query) {
+    return given()
+      .config(config)
+      .spec(requestSpecification)
+      .when()
+      .get("/users?query=" + query)
+      .then()
+      .statusCode(HTTP_OK)
+      .extract().as(Users.class);
   }
 
   public void deleteAllUsers() {

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -1,15 +1,21 @@
 package org.folio.support.http;
 
 import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.net.HttpURLConnection.HTTP_CREATED;
 
 import java.net.URI;
+
+import org.folio.support.User;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.LogConfig;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.mapper.ObjectMapperType;
+import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import lombok.NonNull;
 
 public class UsersClient {
   private final RequestSpecification requestSpecification;
@@ -26,6 +32,23 @@ public class UsersClient {
     config = RestAssuredConfig.newConfig()
       .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2))
       .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails());
+  }
+
+  public User createUser(@NonNull User user) {
+    return attemptToCreateUser(user)
+      .statusCode(HTTP_CREATED)
+      .extract().as(User.class);
+  }
+
+  public ValidatableResponse attemptToCreateUser(@NonNull User user) {
+    return given()
+      .config(config)
+      .spec(requestSpecification)
+      .contentType(JSON)
+      .when()
+      .body(user)
+      .post("/users")
+      .then();
   }
 
   public void deleteAllUsers() {

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -66,12 +66,13 @@ public class UsersClient {
       .extract().as(User.class);
   }
 
-  public Users getUsers(String query) {
+  public Users getUsers(String cqlQuery) {
     return given()
       .config(config)
       .spec(requestSpecification)
       .when()
-      .get("/users?query=" + query)
+      .queryParam("query", cqlQuery)
+      .get("/users")
       .then()
       .statusCode(HTTP_OK)
       .extract().as(Users.class);
@@ -82,7 +83,7 @@ public class UsersClient {
       .config(config)
       .spec(requestSpecification)
       .when()
-      .param("query", "cql.allRecords=1")
+      .queryParam("query", "cql.allRecords=1")
       .delete("/users")
       .then()
       .statusCode(204);

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -3,6 +3,7 @@ package org.folio.support.http;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.net.URI;
@@ -85,5 +86,20 @@ public class UsersClient {
       .delete("/users")
       .then()
       .statusCode(204);
+  }
+  public void updateUser(@NonNull User user) {
+    attemptToUpdateUser(user)
+      .statusCode(HTTP_NO_CONTENT);
+  }
+
+  public ValidatableResponse attemptToUpdateUser(@NonNull User user) {
+    return given()
+      .config(config)
+      .spec(requestSpecification)
+      .contentType(JSON)
+      .when()
+      .body(user)
+      .put("/users/{id}", Map.of("id", user.getId()))
+      .then();
   }
 }


### PR DESCRIPTION
*Purpose*

Reduce the number of [reported code smells](https://sonarcloud.io/project/issues?resolved=false&id=org.folio%3Amod-users)

*Approach*
* Use hamcrest for assertions (instead of vert.x context)
* Use vert.x junit 5.0 integration for groups integration test
* Use rest assured for making requests to the APIs
* Introduce classes for easier creation / inspection of JSON representations of users and groups
* Split up the existing test in individual tests (to reduce complexity and improve feedback)
* Extract use of rest assured to separate client classes


*TODO*
* Move the tests relating to users to the users integration tests (requires improvement to that test class first)
* Reduce complexity of rest verticle integration tests by splitting examples into separate tests
