### PR TITLE
Consolidate rest assured usage MODUSERS-309

### DIFF
--- a/src/test/java/org/folio/moduserstest/ExpirationIT.java
+++ b/src/test/java/org/folio/moduserstest/ExpirationIT.java
@@ -41,7 +41,7 @@ class ExpirationIT {
     final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
 
     usersClient = new UsersClient(okapiUrl, headers);
-    expirationClient = new ExpirationClient(okapiUrl.asURI(), headers);
+    expirationClient = new ExpirationClient(okapiUrl, headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/moduserstest/ExpirationIT.java
+++ b/src/test/java/org/folio/moduserstest/ExpirationIT.java
@@ -38,12 +38,11 @@ class ExpirationIT {
 
     int port = NetworkUtils.nextFreePort();
 
-    final var headers = new OkapiHeaders("http://localhost:" + port,
-      "diku", "diku");
+    final var okapiUrl = "http://localhost:" + port;
+    final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
 
-    usersClient = new UsersClient(new URI("http://localhost:" + port), headers);
-    expirationClient = new ExpirationClient(
-      new URI("http://localhost:" + port), headers);
+    usersClient = new UsersClient(new URI(okapiUrl), headers);
+    expirationClient = new ExpirationClient(new URI(okapiUrl), headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/moduserstest/ExpirationIT.java
+++ b/src/test/java/org/folio/moduserstest/ExpirationIT.java
@@ -5,14 +5,13 @@ import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 
-import java.net.URI;
-
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.support.VertxModule;
 import org.folio.support.http.ExpirationClient;
 import org.folio.support.http.OkapiHeaders;
+import org.folio.support.http.OkapiUrl;
 import org.folio.support.http.UsersClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,11 +37,11 @@ class ExpirationIT {
 
     int port = NetworkUtils.nextFreePort();
 
-    final var okapiUrl = "http://localhost:" + port;
+    final var okapiUrl = new OkapiUrl( "http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
 
-    usersClient = new UsersClient(new URI(okapiUrl), headers);
-    expirationClient = new ExpirationClient(new URI(okapiUrl), headers);
+    usersClient = new UsersClient(okapiUrl, headers);
+    expirationClient = new ExpirationClient(okapiUrl.asURI(), headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -8,7 +8,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
-import java.net.URI;
 import java.util.UUID;
 
 import org.folio.postgres.testing.PostgresTesterContainer;
@@ -20,6 +19,7 @@ import org.folio.support.ValidationErrors;
 import org.folio.support.VertxModule;
 import org.folio.support.http.GroupsClient;
 import org.folio.support.http.OkapiHeaders;
+import org.folio.support.http.OkapiUrl;
 import org.folio.support.http.UsersClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,11 +47,11 @@ class GroupIT {
 
     int port = NetworkUtils.nextFreePort();
 
-    final var okapiUrl = "http://localhost:" + port;
+    final var okapiUrl = new OkapiUrl( "http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
 
-    groupsClient = new GroupsClient(new URI(okapiUrl), headers);
-    usersClient = new UsersClient(new URI(okapiUrl), headers);
+    groupsClient = new GroupsClient(okapiUrl, headers);
+    usersClient = new UsersClient(okapiUrl.asURI(), headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -227,7 +227,7 @@ class GroupIT {
       .desc("Second group description")
       .build());
 
-    final var groups = groupsClient.findGroups("group==Second");
+    final var groups = groupsClient.getGroups("group==Second");
 
     assertThat(groups.getTotalRecords(), is(1));
 

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -51,7 +51,7 @@ class GroupIT {
     final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
 
     groupsClient = new GroupsClient(okapiUrl, headers);
-    usersClient = new UsersClient(okapiUrl.asURI(), headers);
+    usersClient = new UsersClient(okapiUrl, headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -47,11 +47,11 @@ class GroupIT {
 
     int port = NetworkUtils.nextFreePort();
 
-    final var headers = new OkapiHeaders("http://localhost:" + port,
-      "diku", "diku");
+    final var okapiUrl = "http://localhost:" + port;
+    final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
 
-    groupsClient = new GroupsClient(new URI("http://localhost:" + port), headers);
-    usersClient = new UsersClient(new URI("http://localhost:" + port), headers);
+    groupsClient = new GroupsClient(new URI(okapiUrl), headers);
+    usersClient = new UsersClient(new URI(okapiUrl), headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/moduserstest/ProxyRelationshipsIT.java
+++ b/src/test/java/org/folio/moduserstest/ProxyRelationshipsIT.java
@@ -9,7 +9,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
 
-import java.net.URI;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -20,6 +19,7 @@ import org.folio.support.ProxyRelationship;
 import org.folio.support.ValidationErrors;
 import org.folio.support.VertxModule;
 import org.folio.support.http.OkapiHeaders;
+import org.folio.support.http.OkapiUrl;
 import org.folio.support.http.ProxiesClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,10 +50,10 @@ class ProxyRelationshipsIT {
 
     int port = NetworkUtils.nextFreePort();
 
-    final var okapiUrl = "http://localhost:" + port;
+    final var okapiUrl = new OkapiUrl( "http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
 
-    proxiesClient = new ProxiesClient(new URI(okapiUrl), headers);
+    proxiesClient = new ProxiesClient(okapiUrl, headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/moduserstest/ProxyRelationshipsIT.java
+++ b/src/test/java/org/folio/moduserstest/ProxyRelationshipsIT.java
@@ -50,10 +50,10 @@ class ProxyRelationshipsIT {
 
     int port = NetworkUtils.nextFreePort();
 
-    final var headers = new OkapiHeaders("http://localhost:" + port,
-      "diku", "diku");
+    final var okapiUrl = "http://localhost:" + port;
+    final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
 
-    proxiesClient = new ProxiesClient(new URI("http://localhost:" + port), headers);
+    proxiesClient = new ProxiesClient(new URI(okapiUrl), headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/rest/impl/AddressTypesIT.java
+++ b/src/test/java/org/folio/rest/impl/AddressTypesIT.java
@@ -60,7 +60,7 @@ class AddressTypesIT {
     final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
     usersClient = new UsersClient(okapiUrl.asURI(), headers);
-    groupsClient = new GroupsClient(okapiUrl.asURI(), headers);
+    groupsClient = new GroupsClient(okapiUrl, headers);
     addressTypesClient = new AddressTypesClient(okapiUrl, headers);
 
     final var module = new VertxModule(vertx);

--- a/src/test/java/org/folio/rest/impl/AddressTypesIT.java
+++ b/src/test/java/org/folio/rest/impl/AddressTypesIT.java
@@ -59,7 +59,7 @@ class AddressTypesIT {
     final var okapiUrl = new OkapiUrl("http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
-    usersClient = new UsersClient(okapiUrl.asURI(), headers);
+    usersClient = new UsersClient(okapiUrl, headers);
     groupsClient = new GroupsClient(okapiUrl, headers);
     addressTypesClient = new AddressTypesClient(okapiUrl, headers);
 

--- a/src/test/java/org/folio/rest/impl/AddressTypesIT.java
+++ b/src/test/java/org/folio/rest/impl/AddressTypesIT.java
@@ -10,7 +10,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
-import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
@@ -27,6 +26,7 @@ import org.folio.support.http.AddressTypesClient;
 import org.folio.support.http.FakeTokenGenerator;
 import org.folio.support.http.GroupsClient;
 import org.folio.support.http.OkapiHeaders;
+import org.folio.support.http.OkapiUrl;
 import org.folio.support.http.UsersClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,12 +56,12 @@ class AddressTypesIT {
 
     final var port = NetworkUtils.nextFreePort();
 
-    final var okapiUrl = "http://localhost:" + port;
+    final var okapiUrl = new OkapiUrl("http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
-    usersClient = new UsersClient(new URI(okapiUrl), headers);
-    groupsClient = new GroupsClient(new URI(okapiUrl), headers);
-    addressTypesClient = new AddressTypesClient(new URI(okapiUrl), headers);
+    usersClient = new UsersClient(okapiUrl.asURI(), headers);
+    groupsClient = new GroupsClient(okapiUrl.asURI(), headers);
+    addressTypesClient = new AddressTypesClient(okapiUrl, headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/rest/impl/AddressTypesIT.java
+++ b/src/test/java/org/folio/rest/impl/AddressTypesIT.java
@@ -56,13 +56,12 @@ class AddressTypesIT {
 
     final var port = NetworkUtils.nextFreePort();
 
-    final var headers = new OkapiHeaders("http://localhost:" + port,
-      tenant, token);
+    final var okapiUrl = "http://localhost:" + port;
+    final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
-    usersClient = new UsersClient(new URI("http://localhost:" + port), headers);
-    groupsClient = new GroupsClient(new URI("http://localhost:" + port), headers);
-    addressTypesClient = new AddressTypesClient(
-      new URI("http://localhost:" + port), headers);
+    usersClient = new UsersClient(new URI(okapiUrl), headers);
+    groupsClient = new GroupsClient(new URI(okapiUrl), headers);
+    addressTypesClient = new AddressTypesClient(new URI(okapiUrl), headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
@@ -119,12 +119,12 @@ class PatronPinAPIIT {
   }
 
   private void enteredPinIsValid(User user, String pin) {
-    patronPinClient.verifyPatronPin(user.getId(), pin)
+    patronPinClient.attemptToVerifyPatronPin(user.getId(), pin)
       .statusCode(is(200));
   }
 
   private void enteredPinIsInvalid(User user, String pin) {
-    patronPinClient.verifyPatronPin(user.getId(), pin)
+    patronPinClient.attemptToVerifyPatronPin(user.getId(), pin)
       .statusCode(is(422));
   }
 

--- a/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
@@ -4,8 +4,6 @@ package org.folio.rest.impl;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 
-import java.net.URI;
-
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -13,6 +11,7 @@ import org.folio.support.User;
 import org.folio.support.VertxModule;
 import org.folio.support.http.FakeTokenGenerator;
 import org.folio.support.http.OkapiHeaders;
+import org.folio.support.http.OkapiUrl;
 import org.folio.support.http.PatronPinClient;
 import org.folio.support.http.UsersClient;
 import org.folio.test.util.DBTestUtil;
@@ -46,11 +45,11 @@ class PatronPinAPIIT {
 
     final var port = NetworkUtils.nextFreePort();
 
-    final var okapiUrl = "http://localhost:" + port;
+    final var okapiUrl = new OkapiUrl( "http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, TENANT, token);
 
-    usersClient = new UsersClient(new URI(okapiUrl), headers);
-    patronPinClient = new PatronPinClient(new URI(okapiUrl), headers);
+    usersClient = new UsersClient(okapiUrl, headers);
+    patronPinClient = new PatronPinClient(okapiUrl.asURI(), headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
@@ -46,18 +46,17 @@ class PatronPinAPIIT {
 
     final var port = NetworkUtils.nextFreePort();
 
-    final var headers = new OkapiHeaders("http://localhost:" + port,
-      TENANT, token);
+    final var okapiUrl = "http://localhost:" + port;
+    final var headers = new OkapiHeaders(okapiUrl, TENANT, token);
 
-    usersClient = new UsersClient(new URI("http://localhost:" + port), headers);
-    patronPinClient = new PatronPinClient(new URI("http://localhost:" + port), headers);
+    usersClient = new UsersClient(new URI(okapiUrl), headers);
+    patronPinClient = new PatronPinClient(new URI(okapiUrl), headers);
 
     final var module = new VertxModule(vertx);
 
     module.deployModule(port)
-      .onComplete(context.succeeding(res -> module.enableModule(headers,
-          false, false)
-        .onComplete(context.succeedingThenComplete())));
+      .compose(res -> module.enableModule(headers)
+      .onComplete(context.succeedingThenComplete()));
   }
 
   @BeforeEach

--- a/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
+++ b/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
@@ -47,7 +47,7 @@ class ReferenceAndSampleDataIT {
     final var okapiUrl = new OkapiUrl( "http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
-    usersClient = new UsersClient(okapiUrl.asURI(), headers);
+    usersClient = new UsersClient(okapiUrl, headers);
     groupsClient = new GroupsClient(okapiUrl, headers);
     addressTypesClient = new AddressTypesClient(okapiUrl, headers);
 

--- a/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
+++ b/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
@@ -6,8 +6,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-import java.net.URI;
-
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -16,6 +14,7 @@ import org.folio.support.http.AddressTypesClient;
 import org.folio.support.http.FakeTokenGenerator;
 import org.folio.support.http.GroupsClient;
 import org.folio.support.http.OkapiHeaders;
+import org.folio.support.http.OkapiUrl;
 import org.folio.support.http.UsersClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -45,12 +44,12 @@ class ReferenceAndSampleDataIT {
 
     final var port = NetworkUtils.nextFreePort();
 
-    final var okapiUrl = "http://localhost:" + port;
+    final var okapiUrl = new OkapiUrl( "http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
-    usersClient = new UsersClient(new URI(okapiUrl), headers);
-    groupsClient = new GroupsClient(new URI(okapiUrl), headers);
-    addressTypesClient = new AddressTypesClient(new URI(okapiUrl), headers);
+    usersClient = new UsersClient(okapiUrl.asURI(), headers);
+    groupsClient = new GroupsClient(okapiUrl.asURI(), headers);
+    addressTypesClient = new AddressTypesClient(okapiUrl, headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
+++ b/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
@@ -48,7 +48,7 @@ class ReferenceAndSampleDataIT {
     final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
     usersClient = new UsersClient(okapiUrl.asURI(), headers);
-    groupsClient = new GroupsClient(okapiUrl.asURI(), headers);
+    groupsClient = new GroupsClient(okapiUrl, headers);
     addressTypesClient = new AddressTypesClient(okapiUrl, headers);
 
     final var module = new VertxModule(vertx);

--- a/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
+++ b/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
@@ -45,13 +45,12 @@ class ReferenceAndSampleDataIT {
 
     final var port = NetworkUtils.nextFreePort();
 
-    final var headers = new OkapiHeaders("http://localhost:" + port,
-      tenant, token);
+    final var okapiUrl = "http://localhost:" + port;
+    final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
-    usersClient = new UsersClient(new URI("http://localhost:" + port), headers);
-    groupsClient = new GroupsClient(new URI("http://localhost:" + port), headers);
-    addressTypesClient = new AddressTypesClient(
-      new URI("http://localhost:" + port), headers);
+    usersClient = new UsersClient(new URI(okapiUrl), headers);
+    groupsClient = new GroupsClient(new URI(okapiUrl), headers);
+    addressTypesClient = new AddressTypesClient(new URI(okapiUrl), headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -62,7 +62,7 @@ class UsersAPIIT {
     final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
     usersClient = new UsersClient(okapiUrl.asURI(), headers);
-    groupsClient = new GroupsClient(okapiUrl.asURI(), headers);
+    groupsClient = new GroupsClient(okapiUrl, headers);
     addressTypesClient = new AddressTypesClient(okapiUrl, headers);
 
     final var module = new VertxModule(vertx);

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -47,7 +47,7 @@ class UsersAPIIT {
   private static UsersClient usersClient;
   private static GroupsClient groupsClient;
   private static AddressTypesClient addressTypesClient;
-
+  
   @BeforeAll
   @SneakyThrows
   static void beforeAll(Vertx vertx, VertxTestContext context) {

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -10,7 +10,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,6 +28,7 @@ import org.folio.support.http.AddressTypesClient;
 import org.folio.support.http.FakeTokenGenerator;
 import org.folio.support.http.GroupsClient;
 import org.folio.support.http.OkapiHeaders;
+import org.folio.support.http.OkapiUrl;
 import org.folio.support.http.UsersClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,12 +58,12 @@ class UsersAPIIT {
 
     final var port = NetworkUtils.nextFreePort();
 
-    final var okapiUrl = "http://localhost:" + port;
+    final var okapiUrl = new OkapiUrl("http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
-    usersClient = new UsersClient(new URI(okapiUrl), headers);
-    groupsClient = new GroupsClient(new URI(okapiUrl), headers);
-    addressTypesClient = new AddressTypesClient(new URI(okapiUrl), headers);
+    usersClient = new UsersClient(okapiUrl.asURI(), headers);
+    groupsClient = new GroupsClient(okapiUrl.asURI(), headers);
+    addressTypesClient = new AddressTypesClient(okapiUrl, headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -61,7 +61,7 @@ class UsersAPIIT {
     final var okapiUrl = new OkapiUrl("http://localhost:" + port);
     final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
-    usersClient = new UsersClient(okapiUrl.asURI(), headers);
+    usersClient = new UsersClient(okapiUrl, headers);
     groupsClient = new GroupsClient(okapiUrl, headers);
     addressTypesClient = new AddressTypesClient(okapiUrl, headers);
 

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -47,7 +47,7 @@ class UsersAPIIT {
   private static UsersClient usersClient;
   private static GroupsClient groupsClient;
   private static AddressTypesClient addressTypesClient;
-  
+
   @BeforeAll
   @SneakyThrows
   static void beforeAll(Vertx vertx, VertxTestContext context) {
@@ -58,13 +58,12 @@ class UsersAPIIT {
 
     final var port = NetworkUtils.nextFreePort();
 
-    final var headers = new OkapiHeaders("http://localhost:" + port,
-      tenant, token);
+    final var okapiUrl = "http://localhost:" + port;
+    final var headers = new OkapiHeaders(okapiUrl, tenant, token);
 
-    usersClient = new UsersClient(new URI("http://localhost:" + port), headers);
-    groupsClient = new GroupsClient(new URI("http://localhost:" + port), headers);
-    addressTypesClient = new AddressTypesClient(
-      new URI("http://localhost:" + port), headers);
+    usersClient = new UsersClient(new URI(okapiUrl), headers);
+    groupsClient = new GroupsClient(new URI(okapiUrl), headers);
+    addressTypesClient = new AddressTypesClient(new URI(okapiUrl), headers);
 
     final var module = new VertxModule(vertx);
 

--- a/src/test/java/org/folio/support/http/AddressTypesClient.java
+++ b/src/test/java/org/folio/support/http/AddressTypesClient.java
@@ -54,17 +54,11 @@ public class AddressTypesClient {
   }
 
   public void deleteAddressType(String id) {
-    attemptToDeleteAddressType(id)
-      .statusCode(HTTP_NO_CONTENT);
+    client.deleteRecord(id);
   }
 
   public ValidatableResponse attemptToDeleteAddressType(String id) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .delete("/{id}", id)
-      .then();
+    return client.attemptToDeleteRecord(id);
   }
 
   public void deleteAllAddressTypes() {

--- a/src/test/java/org/folio/support/http/AddressTypesClient.java
+++ b/src/test/java/org/folio/support/http/AddressTypesClient.java
@@ -3,7 +3,6 @@ package org.folio.support.http;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
-import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.CoreMatchers.is;
 
 import org.folio.support.AddressType;
@@ -13,15 +12,15 @@ import io.restassured.response.ValidatableResponse;
 import lombok.NonNull;
 
 public class AddressTypesClient {
-  private final RestAssuredClient<AddressType> client;
+  private final RestAssuredClient<AddressType, AddressTypes> client;
 
   public AddressTypesClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
     client = new RestAssuredClient<>(okapiUrl.asURI("/addresstypes"),
-      defaultHeaders);
+      defaultHeaders, AddressType.class, AddressTypes.class);
   }
 
   public AddressType createAddressType(@NonNull AddressType addressType) {
-    return client.createRecord(addressType, AddressType.class);
+    return client.createRecord(addressType);
   }
 
   public ValidatableResponse attemptToCreateAddressType(
@@ -31,27 +30,15 @@ public class AddressTypesClient {
   }
 
   public AddressType getAddressType(String id) {
-    return client.getRecord(id, AddressType.class);
+    return client.getRecord(id);
   }
 
   public ValidatableResponse attemptToGetAddressType(String id) {
     return client.attemptToGetRecord(id);
   }
 
-  public AddressTypes getAddressTypes(String cqlQuery) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .queryParam("query", cqlQuery)
-      .get()
-      .then()
-      .statusCode(HTTP_OK)
-      .extract().as(AddressTypes.class);
-  }
-
   public AddressTypes getAllAddressTypes() {
-    return getAddressTypes("cql.AllRecords=1");
+    return client.getAllRecords();
   }
 
   public void updateAddressType(@NonNull AddressType addressType) {

--- a/src/test/java/org/folio/support/http/AddressTypesClient.java
+++ b/src/test/java/org/folio/support/http/AddressTypesClient.java
@@ -1,7 +1,5 @@
 package org.folio.support.http;
 
-import static io.restassured.RestAssured.given;
-import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static org.hamcrest.CoreMatchers.is;
 
@@ -42,14 +40,7 @@ public class AddressTypesClient {
   }
 
   public void updateAddressType(@NonNull AddressType addressType) {
-    given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .contentType(JSON)
-      .when()
-      .body(addressType)
-      .put("/{id}", addressType.getId())
-      .then()
+    client.attemptToUpdateRecord(addressType.getId(), addressType)
       .statusCode(is(HTTP_NO_CONTENT));
   }
 

--- a/src/test/java/org/folio/support/http/AddressTypesClient.java
+++ b/src/test/java/org/folio/support/http/AddressTypesClient.java
@@ -10,10 +10,10 @@ import io.restassured.response.ValidatableResponse;
 import lombok.NonNull;
 
 public class AddressTypesClient {
-  private final RestAssuredClient<AddressType, AddressTypes> client;
+  private final RestAssuredCollectionApiClient<AddressType, AddressTypes> client;
 
   public AddressTypesClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient<>(okapiUrl.asURI("/addresstypes"),
+    client = new RestAssuredCollectionApiClient<>(okapiUrl.asURI("/addresstypes"),
       defaultHeaders, AddressType.class, AddressTypes.class);
   }
 

--- a/src/test/java/org/folio/support/http/AddressTypesClient.java
+++ b/src/test/java/org/folio/support/http/AddressTypesClient.java
@@ -21,21 +21,21 @@ public class AddressTypesClient {
   }
 
   public AddressType createAddressType(@NonNull AddressType addressType) {
-    return client.createRecord("", addressType, AddressType.class);
+    return client.createRecord(addressType, AddressType.class);
   }
 
   public ValidatableResponse attemptToCreateAddressType(
     @NonNull AddressType addressType) {
 
-    return client.attemptToCreateRecord("", addressType);
+    return client.attemptToCreateRecord(addressType);
   }
 
   public AddressType getAddressType(String id) {
-    return client.getRecord("/{id}", id, AddressType.class);
+    return client.getRecord(id, AddressType.class);
   }
 
   public ValidatableResponse attemptToGetAddressType(String id) {
-    return client.attemptToGetRecord("/{id}", id);
+    return client.attemptToGetRecord(id);
   }
 
   public AddressTypes getAddressTypes(String cqlQuery) {

--- a/src/test/java/org/folio/support/http/AddressTypesClient.java
+++ b/src/test/java/org/folio/support/http/AddressTypesClient.java
@@ -32,18 +32,11 @@ public class AddressTypesClient {
   }
 
   public AddressType getAddressType(String id) {
-    return attemptToGetAddressType(id)
-      .statusCode(is(HTTP_OK))
-      .extract().as(AddressType.class);
+    return client.getRecord("/addresstypes/{id}", id, AddressType.class);
   }
 
   public ValidatableResponse attemptToGetAddressType(String id) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .get("/addresstypes/{id}", id)
-      .then();
+    return client.attemptToGetRecord("/addresstypes/{id}", id);
   }
 
   public AddressTypes getAddressTypes(String cqlQuery) {

--- a/src/test/java/org/folio/support/http/AddressTypesClient.java
+++ b/src/test/java/org/folio/support/http/AddressTypesClient.java
@@ -6,8 +6,6 @@ import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.CoreMatchers.is;
 
-import java.net.URI;
-
 import org.folio.support.AddressType;
 import org.folio.support.AddressTypes;
 
@@ -17,26 +15,27 @@ import lombok.NonNull;
 public class AddressTypesClient {
   private final RestAssuredClient<AddressType> client;
 
-  public AddressTypesClient(URI baseUri, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient<>(baseUri, defaultHeaders);
+  public AddressTypesClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
+    client = new RestAssuredClient<>(okapiUrl.asURI("/addresstypes"),
+      defaultHeaders);
   }
 
   public AddressType createAddressType(@NonNull AddressType addressType) {
-    return client.createRecord("/addresstypes", addressType, AddressType.class);
+    return client.createRecord("", addressType, AddressType.class);
   }
 
   public ValidatableResponse attemptToCreateAddressType(
     @NonNull AddressType addressType) {
 
-    return client.attemptToCreateRecord("/addresstypes", addressType);
+    return client.attemptToCreateRecord("", addressType);
   }
 
   public AddressType getAddressType(String id) {
-    return client.getRecord("/addresstypes/{id}", id, AddressType.class);
+    return client.getRecord("/{id}", id, AddressType.class);
   }
 
   public ValidatableResponse attemptToGetAddressType(String id) {
-    return client.attemptToGetRecord("/addresstypes/{id}", id);
+    return client.attemptToGetRecord("/{id}", id);
   }
 
   public AddressTypes getAddressTypes(String cqlQuery) {
@@ -45,7 +44,7 @@ public class AddressTypesClient {
       .spec(client.requestSpecification)
       .when()
       .queryParam("query", cqlQuery)
-      .get("/addresstypes")
+      .get()
       .then()
       .statusCode(HTTP_OK)
       .extract().as(AddressTypes.class);
@@ -62,7 +61,7 @@ public class AddressTypesClient {
       .contentType(JSON)
       .when()
       .body(addressType)
-      .put("/addresstypes/{id}", addressType.getId())
+      .put("/{id}", addressType.getId())
       .then()
       .statusCode(is(HTTP_NO_CONTENT));
   }
@@ -77,7 +76,7 @@ public class AddressTypesClient {
       .config(client.config)
       .spec(client.requestSpecification)
       .when()
-      .delete("/addresstypes/{id}", id)
+      .delete("/{id}", id)
       .then();
   }
 

--- a/src/test/java/org/folio/support/http/AddressTypesClient.java
+++ b/src/test/java/org/folio/support/http/AddressTypesClient.java
@@ -2,7 +2,6 @@ package org.folio.support.http;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.hamcrest.CoreMatchers.is;
@@ -12,49 +11,24 @@ import java.net.URI;
 import org.folio.support.AddressType;
 import org.folio.support.AddressTypes;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.config.LogConfig;
-import io.restassured.config.ObjectMapperConfig;
-import io.restassured.config.RestAssuredConfig;
-import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ValidatableResponse;
-import io.restassured.specification.RequestSpecification;
 import lombok.NonNull;
 
 public class AddressTypesClient {
-  private final RequestSpecification requestSpecification;
-  private final RestAssuredConfig config;
-  public AddressTypesClient(URI baseUri, OkapiHeaders defaultHeaders) {
-    requestSpecification = new RequestSpecBuilder()
-      .setBaseUri(baseUri)
-      .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .addHeader("X-Okapi-Token", defaultHeaders.getToken())
-      .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .setAccept("application/json, text/plain")
-      .build();
+  private final RestAssuredClient<AddressType> client;
 
-    config = RestAssuredConfig.newConfig()
-      .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2))
-      .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails());
+  public AddressTypesClient(URI baseUri, OkapiHeaders defaultHeaders) {
+    client = new RestAssuredClient<>(baseUri, defaultHeaders);
   }
 
   public AddressType createAddressType(@NonNull AddressType addressType) {
-    return attemptToCreateAddressType(addressType)
-      .statusCode(HTTP_CREATED)
-      .extract().as(AddressType.class);
+    return client.createRecord("/addresstypes", addressType, AddressType.class);
   }
 
   public ValidatableResponse attemptToCreateAddressType(
     @NonNull AddressType addressType) {
 
-    return given()
-      .config(config)
-      .spec(requestSpecification)
-      .contentType(JSON)
-      .when()
-      .body(addressType)
-      .post("/addresstypes")
-      .then();
+    return client.attemptToCreateRecord("/addresstypes", addressType);
   }
 
   public AddressType getAddressType(String id) {
@@ -65,8 +39,8 @@ public class AddressTypesClient {
 
   public ValidatableResponse attemptToGetAddressType(String id) {
     return given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .when()
       .get("/addresstypes/{id}", id)
       .then();
@@ -74,8 +48,8 @@ public class AddressTypesClient {
 
   public AddressTypes getAddressTypes(String cqlQuery) {
     return given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .when()
       .queryParam("query", cqlQuery)
       .get("/addresstypes")
@@ -90,8 +64,8 @@ public class AddressTypesClient {
 
   public void updateAddressType(@NonNull AddressType addressType) {
     given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .contentType(JSON)
       .when()
       .body(addressType)
@@ -107,8 +81,8 @@ public class AddressTypesClient {
 
   public ValidatableResponse attemptToDeleteAddressType(String id) {
     return given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .when()
       .delete("/addresstypes/{id}", id)
       .then();

--- a/src/test/java/org/folio/support/http/ExpirationClient.java
+++ b/src/test/java/org/folio/support/http/ExpirationClient.java
@@ -1,39 +1,16 @@
 package org.folio.support.http;
 
-import static io.restassured.RestAssured.given;
-
-import java.net.URI;
-
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.config.LogConfig;
-import io.restassured.config.ObjectMapperConfig;
-import io.restassured.config.RestAssuredConfig;
-import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ValidatableResponse;
-import io.restassured.specification.RequestSpecification;
 
 public class ExpirationClient {
-  private final RequestSpecification requestSpecification;
-  private final RestAssuredConfig config;
+  private final RestAssuredConfiguration configuration;
 
-  public ExpirationClient(URI baseUri, OkapiHeaders defaultHeaders) {
-    requestSpecification = new RequestSpecBuilder()
-      .setBaseUri(baseUri)
-      .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .addHeader("X-Okapi-Token", defaultHeaders.getToken())
-      .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .setAccept("application/json, text/plain")
-      .build();
-
-    config = RestAssuredConfig.newConfig()
-      .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2))
-      .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails());
+  public ExpirationClient(OkapiUrl baseUri, OkapiHeaders defaultHeaders) {
+    configuration = new RestAssuredConfiguration(baseUri.asURI(), defaultHeaders);
   }
 
   public ValidatableResponse attemptToTriggerExpiration(String tenantId) {
-    return given()
-      .config(config)
-      .spec(requestSpecification)
+    return configuration.initialSpecification()
       .header("X-Okapi-Tenant", tenantId)
       .when()
       .post("/users/expire/timer")

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -10,10 +10,10 @@ import lombok.NonNull;
 
 public class GroupsClient {
 
-  private final RestAssuredClient<Group, Groups> client;
+  private final RestAssuredCollectionApiClient<Group, Groups> client;
 
   public GroupsClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient<>(okapiUrl.asURI("/groups"),
+    client = new RestAssuredCollectionApiClient<>(okapiUrl.asURI("/groups"),
       defaultHeaders, Group.class, Groups.class);
   }
 

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -5,7 +5,6 @@ import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 
-import java.net.URI;
 import java.util.Map;
 
 import org.folio.support.Group;
@@ -18,16 +17,16 @@ public class GroupsClient {
 
   private final RestAssuredClient<Group> client;
 
-  public GroupsClient(URI baseUri, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient<>(baseUri, defaultHeaders);
+  public GroupsClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
+    client = new RestAssuredClient<>(okapiUrl.asURI("/groups"), defaultHeaders);
   }
 
   public Group createGroup(@NonNull Group group) {
-    return client.createRecord("/groups", group, Group.class);
+    return client.createRecord("", group, Group.class);
   }
 
   public ValidatableResponse attemptToCreateGroup(@NonNull Group group) {
-    return client.attemptToCreateRecord("/groups", group);
+    return client.attemptToCreateRecord("", group);
   }
 
   public Groups getAllGroups() {
@@ -35,7 +34,7 @@ public class GroupsClient {
       .config(client.config)
       .spec(client.requestSpecification)
       .when()
-      .get("/groups")
+      .get()
       .then()
       .statusCode(HTTP_OK)
       .extract().as(Groups.class);
@@ -51,7 +50,7 @@ public class GroupsClient {
       .config(client.config)
       .spec(client.requestSpecification)
       .when()
-      .delete("/groups/{id}", Map.of("id", id))
+      .delete("/{id}", Map.of("id", id))
       .then();
   }
 
@@ -62,11 +61,11 @@ public class GroupsClient {
   }
 
   public Group getGroup(String id) {
-    return client.getRecord("/groups/{id}", id, Group.class);
+    return client.getRecord("/{id}", id, Group.class);
   }
 
   public ValidatableResponse attemptToGetGroup(String id) {
-    return client.attemptToGetRecord("/groups/{id}", id);
+    return client.attemptToGetRecord("/{id}", id);
   }
 
   public Groups findGroups(String cqlQuery) {
@@ -75,7 +74,7 @@ public class GroupsClient {
       .spec(client.requestSpecification)
       .when()
       .queryParam("query", cqlQuery)
-      .get("/groups")
+      .get()
       .then()
       .statusCode(HTTP_OK)
       .extract().as(Groups.class);
@@ -87,7 +86,7 @@ public class GroupsClient {
       .contentType(JSON)
       .when()
       .body(group)
-      .put("/groups/{id}", Map.of("id", group.getId()))
+      .put("/{id}", Map.of("id", group.getId()))
       .then()
       .statusCode(HTTP_NO_CONTENT);
   }

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -62,18 +62,11 @@ public class GroupsClient {
   }
 
   public Group getGroup(String id) {
-    return attemptToGetGroup(id)
-      .statusCode(HTTP_OK)
-      .extract().as(Group.class);
+    return client.getRecord("/groups/{id}", id, Group.class);
   }
 
   public ValidatableResponse attemptToGetGroup(String id) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .get("/groups/{id}", Map.of("id", id))
-      .then();
+    return client.attemptToGetRecord("/groups/{id}", id);
   }
 
   public Groups findGroups(String cqlQuery) {

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -1,10 +1,6 @@
 package org.folio.support.http;
 
-import static io.restassured.RestAssured.given;
-import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
-
-import java.util.Map;
 
 import org.folio.support.Group;
 import org.folio.support.Groups;
@@ -60,13 +56,7 @@ public class GroupsClient {
   }
 
   public void updateGroup(@NonNull Group group) {
-    given()
-      .spec(client.requestSpecification)
-      .contentType(JSON)
-      .when()
-      .body(group)
-      .put("/{id}", Map.of("id", group.getId()))
-      .then()
+    client.attemptToUpdateRecord(group.getId(), group)
       .statusCode(HTTP_NO_CONTENT);
   }
 }

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -22,11 +22,11 @@ public class GroupsClient {
   }
 
   public Group createGroup(@NonNull Group group) {
-    return client.createRecord("", group, Group.class);
+    return client.createRecord(group, Group.class);
   }
 
   public ValidatableResponse attemptToCreateGroup(@NonNull Group group) {
-    return client.attemptToCreateRecord("", group);
+    return client.attemptToCreateRecord(group);
   }
 
   public Groups getAllGroups() {
@@ -61,11 +61,11 @@ public class GroupsClient {
   }
 
   public Group getGroup(String id) {
-    return client.getRecord("/{id}", id, Group.class);
+    return client.getRecord(id, Group.class);
   }
 
   public ValidatableResponse attemptToGetGroup(String id) {
-    return client.attemptToGetRecord("/{id}", id);
+    return client.attemptToGetRecord(id);
   }
 
   public Groups findGroups(String cqlQuery) {

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -30,17 +30,11 @@ public class GroupsClient {
   }
 
   public void deleteGroup(String id) {
-    attemptToDeleteGroup(id)
-      .statusCode(HTTP_NO_CONTENT);
+    client.deleteRecord(id);
   }
 
   public ValidatableResponse attemptToDeleteGroup(String id) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .delete("/{id}", Map.of("id", id))
-      .then();
+    return client.attemptToDeleteRecord(id);
   }
 
   public void deleteAllGroups() {

--- a/src/test/java/org/folio/support/http/GroupsClient.java
+++ b/src/test/java/org/folio/support/http/GroupsClient.java
@@ -3,7 +3,6 @@ package org.folio.support.http;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
-import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.util.Map;
 
@@ -15,29 +14,19 @@ import lombok.NonNull;
 
 public class GroupsClient {
 
-  private final RestAssuredClient<Group> client;
+  private final RestAssuredClient<Group, Groups> client;
 
   public GroupsClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient<>(okapiUrl.asURI("/groups"), defaultHeaders);
+    client = new RestAssuredClient<>(okapiUrl.asURI("/groups"),
+      defaultHeaders, Group.class, Groups.class);
   }
 
   public Group createGroup(@NonNull Group group) {
-    return client.createRecord(group, Group.class);
+    return client.createRecord(group);
   }
 
   public ValidatableResponse attemptToCreateGroup(@NonNull Group group) {
     return client.attemptToCreateRecord(group);
-  }
-
-  public Groups getAllGroups() {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .get()
-      .then()
-      .statusCode(HTTP_OK)
-      .extract().as(Groups.class);
   }
 
   public void deleteGroup(String id) {
@@ -61,23 +50,19 @@ public class GroupsClient {
   }
 
   public Group getGroup(String id) {
-    return client.getRecord(id, Group.class);
+    return client.getRecord(id);
   }
 
   public ValidatableResponse attemptToGetGroup(String id) {
     return client.attemptToGetRecord(id);
   }
 
-  public Groups findGroups(String cqlQuery) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .queryParam("query", cqlQuery)
-      .get()
-      .then()
-      .statusCode(HTTP_OK)
-      .extract().as(Groups.class);
+  public Groups getGroups(String cqlQuery) {
+    return client.getRecords(cqlQuery);
+  }
+
+  public Groups getAllGroups() {
+    return client.getAllRecords();
   }
 
   public void updateGroup(@NonNull Group group) {

--- a/src/test/java/org/folio/support/http/OkapiHeaders.java
+++ b/src/test/java/org/folio/support/http/OkapiHeaders.java
@@ -1,10 +1,16 @@
 package org.folio.support.http;
 
+import lombok.AllArgsConstructor;
 import lombok.Value;
 
 @Value
+@AllArgsConstructor
 public class OkapiHeaders {
   String okapiUrl;
   String tenantId;
   String token;
+
+  public OkapiHeaders(OkapiUrl okapiUrl, String tenantId, String token) {
+    this(okapiUrl.toString(), tenantId, token);
+  }
 }

--- a/src/test/java/org/folio/support/http/OkapiUrl.java
+++ b/src/test/java/org/folio/support/http/OkapiUrl.java
@@ -1,0 +1,28 @@
+package org.folio.support.http;
+
+import java.net.URI;
+
+import lombok.SneakyThrows;
+
+public class OkapiUrl {
+  private final String url;
+
+  public OkapiUrl(String url) {
+    this.url = url;
+  }
+
+  @Override
+  public String toString() {
+    return url;
+  }
+
+  @SneakyThrows
+  public URI asURI() {
+    return new URI(url);
+  }
+
+  @SneakyThrows
+  public URI asURI(String path) {
+    return new URI(url + path);
+  }
+}

--- a/src/test/java/org/folio/support/http/PatronPinClient.java
+++ b/src/test/java/org/folio/support/http/PatronPinClient.java
@@ -28,7 +28,7 @@ public class PatronPinClient {
       .statusCode(201);
   }
 
-  public ValidatableResponse verifyPatronPin(String userId, String pin) {
+  public ValidatableResponse attemptToVerifyPatronPin(String userId, String pin) {
     return configuration.initialSpecification()
       .contentType(JSON)
       .when()

--- a/src/test/java/org/folio/support/http/PatronPinClient.java
+++ b/src/test/java/org/folio/support/http/PatronPinClient.java
@@ -2,7 +2,6 @@ package org.folio.support.http;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static org.hamcrest.CoreMatchers.is;
 
 import java.net.URI;
 
@@ -75,5 +74,4 @@ public class PatronPinClient {
       .then()
       .statusCode(200);
   }
-
 }

--- a/src/test/java/org/folio/support/http/PatronPinClient.java
+++ b/src/test/java/org/folio/support/http/PatronPinClient.java
@@ -1,41 +1,22 @@
 package org.folio.support.http;
 
-import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 
 import java.net.URI;
 
 import org.folio.support.PatronPin;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.config.LogConfig;
-import io.restassured.config.ObjectMapperConfig;
-import io.restassured.config.RestAssuredConfig;
-import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ValidatableResponse;
-import io.restassured.specification.RequestSpecification;
 
 public class PatronPinClient {
-  private final RequestSpecification requestSpecification;
-  private final RestAssuredConfig config;
-  public PatronPinClient(URI baseUri, OkapiHeaders defaultHeaders) {
-    requestSpecification = new RequestSpecBuilder()
-      .setBaseUri(baseUri)
-      .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .addHeader("X-Okapi-Token", defaultHeaders.getToken())
-      .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .setAccept("application/json, text/plain")
-      .build();
+  private final RestAssuredConfiguration configuration;
 
-    config = RestAssuredConfig.newConfig()
-      .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2))
-      .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails());
+  public PatronPinClient(URI baseUri, OkapiHeaders defaultHeaders) {
+    configuration = new RestAssuredConfiguration(baseUri, defaultHeaders);
   }
 
   public void assignPatronPin(String userId, String pin) {
-    given()
-      .config(config)
-      .spec(requestSpecification)
+    configuration.initialSpecification()
       .contentType(JSON)
       .when()
       .body(PatronPin.builder()
@@ -48,9 +29,7 @@ public class PatronPinClient {
   }
 
   public ValidatableResponse verifyPatronPin(String userId, String pin) {
-    return given()
-      .config(config)
-      .spec(requestSpecification)
+    return configuration.initialSpecification()
       .contentType(JSON)
       .when()
       .body(PatronPin.builder()
@@ -62,9 +41,7 @@ public class PatronPinClient {
   }
 
   public void removePatronPin(String userId) {
-    given()
-      .config(config)
-      .spec(requestSpecification)
+    configuration.initialSpecification()
       .contentType(JSON)
       .when()
       .body(PatronPin.builder()

--- a/src/test/java/org/folio/support/http/ProxiesClient.java
+++ b/src/test/java/org/folio/support/http/ProxiesClient.java
@@ -1,93 +1,45 @@
 package org.folio.support.http;
 
-import static io.restassured.RestAssured.given;
-import static io.restassured.http.ContentType.JSON;
-import static java.net.HttpURLConnection.HTTP_CREATED;
-import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
-import static java.net.HttpURLConnection.HTTP_OK;
-
-import java.net.URI;
-import java.util.Map;
-
 import org.folio.support.ProxyRelationship;
 import org.folio.support.ProxyRelationships;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.config.LogConfig;
-import io.restassured.config.ObjectMapperConfig;
-import io.restassured.config.RestAssuredConfig;
-import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ValidatableResponse;
-import io.restassured.specification.RequestSpecification;
 import lombok.NonNull;
 
 public class ProxiesClient {
-  private final RequestSpecification requestSpecification;
-  private final RestAssuredConfig config;
+  private final RestAssuredClient<ProxyRelationship, ProxyRelationships> client;
 
-  public ProxiesClient(URI baseUri, OkapiHeaders defaultHeaders) {
-    requestSpecification = new RequestSpecBuilder()
-      .setBaseUri(baseUri)
-      .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
-      .addHeader("X-Okapi-Token", defaultHeaders.getToken())
-      .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
-      .setAccept("application/json, text/plain")
-      .build();
-
-    config = RestAssuredConfig.newConfig()
-      .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2))
-      .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails());
+  public ProxiesClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
+    client = new RestAssuredClient<>(okapiUrl.asURI("/proxiesfor"),
+      defaultHeaders, ProxyRelationship.class, ProxyRelationships.class);
   }
 
   public ProxyRelationship createProxyRelationship(
     @NonNull ProxyRelationship proxyRelationship) {
 
-    return attemptToCreateProxyRelationship(proxyRelationship)
-      .statusCode(HTTP_CREATED)
-      .extract().as(ProxyRelationship.class);
+    return client.createRecord(proxyRelationship);
   }
 
   public ValidatableResponse attemptToCreateProxyRelationship(
     @NonNull ProxyRelationship proxyRelationship) {
 
-    return given()
-      .config(config)
-      .spec(requestSpecification)
-      .contentType(JSON)
-      .when()
-      .body(proxyRelationship)
-      .post("/proxiesfor")
-      .then();
+    return client.attemptToCreateRecord(proxyRelationship);
   }
 
   public ProxyRelationships getAllProxyRelationships() {
-    return getProxyRelationships("cql.allRecords=1");
+    return client.getAllRecords();
   }
 
   public ProxyRelationships getProxyRelationships(String cqlQuery) {
-    return given()
-      .config(config)
-      .spec(requestSpecification)
-      .when()
-      .queryParam("query", cqlQuery)
-      .get("/proxiesfor")
-      .then()
-      .statusCode(HTTP_OK)
-      .extract().as(ProxyRelationships.class);
+    return client.getRecords(cqlQuery);
   }
 
   public void deleteProxyRelationship(String id) {
-    attemptToDeleteProxyRelationship(id)
-      .statusCode(HTTP_NO_CONTENT);
+    client.attemptToDeleteRecord(id);
   }
 
   public ValidatableResponse attemptToDeleteProxyRelationship(String id) {
-    return given()
-      .config(config)
-      .spec(requestSpecification)
-      .when()
-      .delete("/proxiesfor/{id}", Map.of("id", id))
-      .then();
+    return client.attemptToDeleteRecord(id);
   }
 
   public void deleteAllProxies() {
@@ -98,30 +50,17 @@ public class ProxiesClient {
   }
 
   public ProxyRelationship getProxyRelationship(String id) {
-    return attemptToGetProxyRelationship(id)
-      .statusCode(HTTP_OK)
-      .extract().as(ProxyRelationship.class);
+    return client.getRecord(id);
   }
 
   public ValidatableResponse attemptToGetProxyRelationship(String id) {
-    return given()
-      .config(config)
-      .spec(requestSpecification)
-      .when()
-      .get("/proxiesfor/{id}", Map.of("id", id))
-      .then();
+    return client.attemptToGetRecord(id);
   }
 
   public ValidatableResponse attemptToUpdateProxyRelationship(
     ProxyRelationship proxyRelationship) {
 
-    return given()
-      .config(config)
-      .spec(requestSpecification)
-      .contentType(JSON)
-      .when()
-      .body(proxyRelationship)
-      .put("/proxiesfor/{id}", Map.of("id", proxyRelationship.getId()))
-      .then();
+    return client.attemptToUpdateRecord(proxyRelationship.getId(),
+      proxyRelationship);
   }
 }

--- a/src/test/java/org/folio/support/http/ProxiesClient.java
+++ b/src/test/java/org/folio/support/http/ProxiesClient.java
@@ -7,10 +7,10 @@ import io.restassured.response.ValidatableResponse;
 import lombok.NonNull;
 
 public class ProxiesClient {
-  private final RestAssuredClient<ProxyRelationship, ProxyRelationships> client;
+  private final RestAssuredCollectionApiClient<ProxyRelationship, ProxyRelationships> client;
 
   public ProxiesClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient<>(okapiUrl.asURI("/proxiesfor"),
+    client = new RestAssuredCollectionApiClient<>(okapiUrl.asURI("/proxiesfor"),
       defaultHeaders, ProxyRelationship.class, ProxyRelationships.class);
   }
 

--- a/src/test/java/org/folio/support/http/RestAssuredClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredClient.java
@@ -26,7 +26,7 @@ public class RestAssuredClient<Record> {
   final RequestSpecification requestSpecification;
   final RestAssuredConfig config;
 
-  public RestAssuredClient(URI baseUri, OkapiHeaders defaultHeaders) {
+  RestAssuredClient(URI baseUri, OkapiHeaders defaultHeaders) {
     this.requestSpecification = new RequestSpecBuilder()
       .setBaseUri(baseUri)
       .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
@@ -48,37 +48,35 @@ public class RestAssuredClient<Record> {
         }));
   }
 
-  Record createRecord(String path, @NotNull Record user, Class<Record> deserializeTo) {
-    return attemptToCreateRecord(path, user)
+  Record createRecord(@NotNull Record user, Class<Record> deserializeTo) {
+    return attemptToCreateRecord(user)
       .statusCode(HTTP_CREATED)
       .extract().as(deserializeTo);
   }
 
-  ValidatableResponse attemptToCreateRecord(String path, @NotNull Record record) {
+  ValidatableResponse attemptToCreateRecord(@NotNull Record record) {
     return given()
       .config(config)
       .spec(requestSpecification)
       .contentType(JSON)
       .when()
       .body(record)
-      .post(path)
+      .post()
       .then();
   }
 
-  <Record> Record getRecord(String parameterisedPath, String id,
-    Class<Record> deserializationClass) {
-
-    return attemptToGetRecord(parameterisedPath, id)
+  Record getRecord(String id, Class<Record> deserializationClass) {
+    return attemptToGetRecord(id)
       .statusCode(HTTP_OK)
       .extract().as(deserializationClass);
   }
 
-  ValidatableResponse attemptToGetRecord(String parameterisedPath, String id) {
+  ValidatableResponse attemptToGetRecord(String id) {
     return given()
       .config(this.config)
       .spec(this.requestSpecification)
       .when()
-      .get(parameterisedPath, Map.of("id", id))
+      .get("/{id}", Map.of("id", id))
       .then();
   }
 }

--- a/src/test/java/org/folio/support/http/RestAssuredClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredClient.java
@@ -1,15 +1,58 @@
 package org.folio.support.http;
 
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+import java.net.URI;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.config.LogConfig;
+import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
+import io.restassured.mapper.ObjectMapperType;
+import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 
 public class RestAssuredClient {
   final RequestSpecification requestSpecification;
   final RestAssuredConfig config;
 
-  public RestAssuredClient(RequestSpecification requestSpecification,
-    RestAssuredConfig config) {
-    this.requestSpecification = requestSpecification;
-    this.config = config;
+  public RestAssuredClient(URI baseUri, OkapiHeaders defaultHeaders) {
+    this.requestSpecification = new RequestSpecBuilder()
+      .setBaseUri(baseUri)
+      .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .addHeader("X-Okapi-Token", defaultHeaders.getToken())
+      .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .setAccept("application/json, text/plain")
+      .build();
+
+    this.config = RestAssuredConfig.newConfig()
+      .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails())
+      .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2)
+        .jackson2ObjectMapperFactory((type, s) -> {
+          final var mapper = new ObjectMapper();
+
+          mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+          mapper.registerModule(new JavaTimeModule());
+
+          return mapper;
+        }));
+  }
+
+  <T> ValidatableResponse attemptToCreateRecord(String path, @NotNull T record) {
+    return given()
+      .config(config)
+      .spec(requestSpecification)
+      .contentType(JSON)
+      .when()
+      .body(record)
+      .post(path)
+      .then();
   }
 }

--- a/src/test/java/org/folio/support/http/RestAssuredClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredClient.java
@@ -2,6 +2,7 @@ package org.folio.support.http;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static java.net.HttpURLConnection.HTTP_CREATED;
 
 import java.net.URI;
 
@@ -19,7 +20,7 @@ import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 
-public class RestAssuredClient {
+public class RestAssuredClient<Record> {
   final RequestSpecification requestSpecification;
   final RestAssuredConfig config;
 
@@ -45,14 +46,20 @@ public class RestAssuredClient {
         }));
   }
 
-  <T> ValidatableResponse attemptToCreateRecord(String path, @NotNull T record) {
+  Record createRecord(@NotNull Record user, Class<Record> deserializeTo) {
+    return attemptToCreateRecord(user)
+      .statusCode(HTTP_CREATED)
+      .extract().as(deserializeTo);
+  }
+
+  ValidatableResponse attemptToCreateRecord(@NotNull Record record) {
     return given()
       .config(config)
       .spec(requestSpecification)
       .contentType(JSON)
       .when()
       .body(record)
-      .post(path)
+      .post("/users")
       .then();
   }
 }

--- a/src/test/java/org/folio/support/http/RestAssuredClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredClient.java
@@ -21,6 +21,7 @@ import io.restassured.config.RestAssuredConfig;
 import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import lombok.NonNull;
 
 public class RestAssuredClient<Record, Collection> {
   final RequestSpecification requestSpecification;
@@ -105,6 +106,17 @@ public class RestAssuredClient<Record, Collection> {
       .when()
       .queryParam("query", cqlQuery)
       .get()
+      .then();
+  }
+
+  ValidatableResponse attemptToUpdateRecord(String id, @NonNull Record record) {
+    return given()
+      .config(this.config)
+      .spec(this.requestSpecification)
+      .contentType(JSON)
+      .when()
+      .body(record)
+      .put("/{id}", Map.of("id", id))
       .then();
   }
 

--- a/src/test/java/org/folio/support/http/RestAssuredClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredClient.java
@@ -107,4 +107,29 @@ public class RestAssuredClient<Record, Collection> {
       .get()
       .then();
   }
+
+  public void deleteRecord(String id) {
+    attemptToDeleteRecord(id)
+      .statusCode(204);
+  }
+
+  ValidatableResponse attemptToDeleteRecord(String id) {
+    return given()
+      .config(this.config)
+      .spec(this.requestSpecification)
+      .when()
+      .delete("/{id}", Map.of("id", id))
+      .then();
+  }
+
+  void deleteRecords(String cqlQuery) {
+    given()
+      .config(this.config)
+      .spec(this.requestSpecification)
+      .when()
+      .queryParam("query", cqlQuery)
+      .delete()
+      .then()
+      .statusCode(204);
+  }
 }

--- a/src/test/java/org/folio/support/http/RestAssuredClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredClient.java
@@ -46,20 +46,20 @@ public class RestAssuredClient<Record> {
         }));
   }
 
-  Record createRecord(@NotNull Record user, Class<Record> deserializeTo) {
-    return attemptToCreateRecord(user)
+  Record createRecord(String path, @NotNull Record user, Class<Record> deserializeTo) {
+    return attemptToCreateRecord(path, user)
       .statusCode(HTTP_CREATED)
       .extract().as(deserializeTo);
   }
 
-  ValidatableResponse attemptToCreateRecord(@NotNull Record record) {
+  ValidatableResponse attemptToCreateRecord(String path, @NotNull Record record) {
     return given()
       .config(config)
       .spec(requestSpecification)
       .contentType(JSON)
       .when()
       .body(record)
-      .post("/users")
+      .post(path)
       .then();
   }
 }

--- a/src/test/java/org/folio/support/http/RestAssuredClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredClient.java
@@ -3,8 +3,10 @@ package org.folio.support.http;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_OK;
 
 import java.net.URI;
+import java.util.Map;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -60,6 +62,23 @@ public class RestAssuredClient<Record> {
       .when()
       .body(record)
       .post(path)
+      .then();
+  }
+
+  <Record> Record getRecord(String parameterisedPath, String id,
+    Class<Record> deserializationClass) {
+
+    return attemptToGetRecord(parameterisedPath, id)
+      .statusCode(HTTP_OK)
+      .extract().as(deserializationClass);
+  }
+
+  ValidatableResponse attemptToGetRecord(String parameterisedPath, String id) {
+    return given()
+      .config(this.config)
+      .spec(this.requestSpecification)
+      .when()
+      .get(parameterisedPath, Map.of("id", id))
       .then();
   }
 }

--- a/src/test/java/org/folio/support/http/RestAssuredClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredClient.java
@@ -1,0 +1,15 @@
+package org.folio.support.http;
+
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.specification.RequestSpecification;
+
+public class RestAssuredClient {
+  final RequestSpecification requestSpecification;
+  final RestAssuredConfig config;
+
+  public RestAssuredClient(RequestSpecification requestSpecification,
+    RestAssuredConfig config) {
+    this.requestSpecification = requestSpecification;
+    this.config = config;
+  }
+}

--- a/src/test/java/org/folio/support/http/RestAssuredCollectionApiClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredCollectionApiClient.java
@@ -23,13 +23,13 @@ import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import lombok.NonNull;
 
-public class RestAssuredClient<Record, Collection> {
+public class RestAssuredCollectionApiClient<Record, Collection> {
   final RequestSpecification requestSpecification;
   final RestAssuredConfig config;
   private final Class<Record> recordDeserializesTo;
   private final Class<Collection> collectionDeserializesTo;
 
-  RestAssuredClient(URI baseUri, OkapiHeaders defaultHeaders,
+  RestAssuredCollectionApiClient(URI baseUri, OkapiHeaders defaultHeaders,
     Class<Record> recordDeserializesTo,
     Class<Collection> collectionDeserializesTo) {
 

--- a/src/test/java/org/folio/support/http/RestAssuredConfiguration.java
+++ b/src/test/java/org/folio/support/http/RestAssuredConfiguration.java
@@ -1,0 +1,50 @@
+package org.folio.support.http;
+
+import static io.restassured.RestAssured.given;
+
+import java.net.URI;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.config.LogConfig;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.mapper.ObjectMapperType;
+import io.restassured.specification.RequestSpecification;
+
+class RestAssuredConfiguration {
+  private final RequestSpecification requestSpecification;
+  private final RestAssuredConfig config;
+
+  public RestAssuredConfiguration(URI baseUri, OkapiHeaders defaultHeaders) {
+    requestSpecification = new RequestSpecBuilder()
+      .setBaseUri(baseUri)
+      .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
+      .addHeader("X-Okapi-Token", defaultHeaders.getToken())
+      .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
+      .setAccept("application/json, text/plain")
+      .build();
+
+    config = RestAssuredConfig.newConfig()
+      .logConfig(
+        new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails())
+      .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2)
+        .jackson2ObjectMapperFactory((type, s) -> {
+          final var mapper = new ObjectMapper();
+
+          mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+          mapper.registerModule(new JavaTimeModule());
+
+          return mapper;
+        }));
+  }
+
+  RequestSpecification initialSpecification() {
+    return given()
+      .config(config)
+      .spec(requestSpecification);
+  }
+}

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -21,7 +21,7 @@ public class UsersClient {
   }
 
   public User createUser(@NonNull User user) {
-    return client.createRecord("", user, User.class);
+    return client.createRecord(user, User.class);
   }
 
   public User createUser(String username) {
@@ -31,15 +31,15 @@ public class UsersClient {
   }
 
   public ValidatableResponse attemptToCreateUser(@NonNull User user) {
-    return client.attemptToCreateRecord("", user);
+    return client.attemptToCreateRecord(user);
   }
 
   public User getUser(String id) {
-    return client.getRecord("/{id}", id, User.class);
+    return client.getRecord(id, User.class);
   }
 
   public ValidatableResponse attemptToGetUser(String id) {
-    return client.attemptToGetRecord("/{id}", id);
+    return client.attemptToGetRecord(id);
   }
 
   public Users getUsers(String cqlQuery) {

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -11,10 +11,10 @@ import io.restassured.response.ValidatableResponse;
 import lombok.NonNull;
 
 public class UsersClient {
-  private final RestAssuredClient<User, Users> client;
+  private final RestAssuredCollectionApiClient<User, Users> client;
 
   public UsersClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient<>(okapiUrl.asURI("/users"),
+    client = new RestAssuredCollectionApiClient<>(okapiUrl.asURI("/users"),
       defaultHeaders, User.class, Users.class);
   }
 

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -1,11 +1,8 @@
 package org.folio.support.http;
 
 import static io.restassured.RestAssured.given;
-import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
-
-import java.util.Map;
 
 import org.folio.support.User;
 import org.folio.support.Users;
@@ -96,13 +93,6 @@ public class UsersClient {
   }
 
   public ValidatableResponse attemptToUpdateUser(String id, @NonNull User user) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .contentType(JSON)
-      .when()
-      .body(user)
-      .put("/{id}", Map.of("id", id))
-      .then();
+    return client.attemptToUpdateRecord(id, user);
   }
 }

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -1,6 +1,5 @@
 package org.folio.support.http;
 
-import static io.restassured.RestAssured.given;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 
@@ -53,9 +52,7 @@ public class UsersClient {
   }
 
   public Users getPatronGroupFacets() {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
+    return client.initialSpecification()
       .when()
       // Limit must be 1 as request fails with limit 0
       // https://issues.folio.org/browse/UIU-1562  https:/issues.folio.org/browse/RMB-722

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -14,14 +14,15 @@ import io.restassured.response.ValidatableResponse;
 import lombok.NonNull;
 
 public class UsersClient {
-  private final RestAssuredClient<User> client;
+  private final RestAssuredClient<User, Users> client;
 
   public UsersClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient<>(okapiUrl.asURI("/users"), defaultHeaders);
+    client = new RestAssuredClient<>(okapiUrl.asURI("/users"),
+      defaultHeaders, User.class, Users.class);
   }
 
   public User createUser(@NonNull User user) {
-    return client.createRecord(user, User.class);
+    return client.createRecord(user);
   }
 
   public User createUser(String username) {
@@ -35,7 +36,7 @@ public class UsersClient {
   }
 
   public User getUser(String id) {
-    return client.getRecord(id, User.class);
+    return client.getRecord(id);
   }
 
   public ValidatableResponse attemptToGetUser(String id) {
@@ -43,23 +44,15 @@ public class UsersClient {
   }
 
   public Users getUsers(String cqlQuery) {
-    return attemptToGetUsers(cqlQuery)
-      .statusCode(HTTP_OK)
-      .extract().as(Users.class);
+    return client.getRecords(cqlQuery);
   }
 
   public ValidatableResponse attemptToGetUsers(String cqlQuery) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .queryParam("query", cqlQuery)
-      .get()
-      .then();
+    return client.attemptToGetRecords(cqlQuery);
   }
 
   public Users getAllUsers() {
-    return getUsers("cql.AllRecords=1");
+    return client.getAllRecords();
   }
 
   public Users getPatronGroupFacets() {

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -5,7 +5,6 @@ import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 
-import java.net.URI;
 import java.util.Map;
 
 import org.folio.support.User;
@@ -17,12 +16,12 @@ import lombok.NonNull;
 public class UsersClient {
   private final RestAssuredClient<User> client;
 
-  public UsersClient(URI baseUri, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient<>(baseUri, defaultHeaders);
+  public UsersClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
+    client = new RestAssuredClient<>(okapiUrl.asURI("/users"), defaultHeaders);
   }
 
   public User createUser(@NonNull User user) {
-    return client.createRecord("/users", user, User.class);
+    return client.createRecord("", user, User.class);
   }
 
   public User createUser(String username) {
@@ -32,15 +31,15 @@ public class UsersClient {
   }
 
   public ValidatableResponse attemptToCreateUser(@NonNull User user) {
-    return client.attemptToCreateRecord("/users", user);
+    return client.attemptToCreateRecord("", user);
   }
 
   public User getUser(String id) {
-    return client.getRecord("/users/{id}", id, User.class);
+    return client.getRecord("/{id}", id, User.class);
   }
 
   public ValidatableResponse attemptToGetUser(String id) {
-    return client.attemptToGetRecord("/users/{id}", id);
+    return client.attemptToGetRecord("/{id}", id);
   }
 
   public Users getUsers(String cqlQuery) {
@@ -55,7 +54,7 @@ public class UsersClient {
       .spec(client.requestSpecification)
       .when()
       .queryParam("query", cqlQuery)
-      .get("/users")
+      .get()
       .then();
   }
 
@@ -72,7 +71,7 @@ public class UsersClient {
       // https://issues.folio.org/browse/UIU-1562  https:/issues.folio.org/browse/RMB-722
       .queryParam("limit", 1)
       .queryParam("facets", "patronGroup:50")
-      .get("/users")
+      .get()
       .then()
       .statusCode(HTTP_OK)
       .extract().as(Users.class);
@@ -88,7 +87,7 @@ public class UsersClient {
       .config(client.config)
       .spec(client.requestSpecification)
       .when()
-      .delete("/users/{id}", Map.of("id", id))
+      .delete("/{id}", Map.of("id", id))
       .then();
   }
 
@@ -98,7 +97,7 @@ public class UsersClient {
       .spec(client.requestSpecification)
       .when()
       .queryParam("query", cqlQuery)
-      .delete("/users")
+      .delete()
       .then()
       .statusCode(204);
   }
@@ -122,7 +121,7 @@ public class UsersClient {
       .contentType(JSON)
       .when()
       .body(user)
-      .put("/users/{id}", Map.of("id", id))
+      .put("/{id}", Map.of("id", id))
       .then();
   }
 }

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -2,7 +2,6 @@ package org.folio.support.http;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 
@@ -16,16 +15,14 @@ import io.restassured.response.ValidatableResponse;
 import lombok.NonNull;
 
 public class UsersClient {
-  private final RestAssuredClient client;
+  private final RestAssuredClient<User> client;
 
   public UsersClient(URI baseUri, OkapiHeaders defaultHeaders) {
-    client = new RestAssuredClient(baseUri, defaultHeaders);
+    client = new RestAssuredClient<>(baseUri, defaultHeaders);
   }
 
   public User createUser(@NonNull User user) {
-    return attemptToCreateUser(user)
-      .statusCode(HTTP_CREATED)
-      .extract().as(User.class);
+    return client.createRecord(user, User.class);
   }
 
   public User createUser(String username) {
@@ -35,7 +32,7 @@ public class UsersClient {
   }
 
   public ValidatableResponse attemptToCreateUser(@NonNull User user) {
-    return client.attemptToCreateRecord("/users", user);
+    return client.attemptToCreateRecord(user);
   }
 
   public User getUser(String id) {

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -71,33 +71,21 @@ public class UsersClient {
   }
 
   public void deleteUser(String id) {
-    attemptToDeleteUser(id)
-      .statusCode(204);
+    client.deleteRecord(id);
   }
 
   public ValidatableResponse attemptToDeleteUser(String id) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .delete("/{id}", Map.of("id", id))
-      .then();
+    return client.attemptToDeleteRecord(id);
   }
 
   public void deleteUsers(String cqlQuery) {
-    given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .queryParam("query", cqlQuery)
-      .delete()
-      .then()
-      .statusCode(204);
+    client.deleteRecords(cqlQuery);
   }
 
   public void deleteAllUsers() {
     deleteUsers("cql.allRecords=1");
   }
+
   public void updateUser(@NonNull User user) {
     attemptToUpdateUser(user)
       .statusCode(HTTP_NO_CONTENT);

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -22,7 +22,7 @@ public class UsersClient {
   }
 
   public User createUser(@NonNull User user) {
-    return client.createRecord(user, User.class);
+    return client.createRecord("/users", user, User.class);
   }
 
   public User createUser(String username) {
@@ -32,7 +32,7 @@ public class UsersClient {
   }
 
   public ValidatableResponse attemptToCreateUser(@NonNull User user) {
-    return client.attemptToCreateRecord(user);
+    return client.attemptToCreateRecord("/users", user);
   }
 
   public User getUser(String id) {

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -22,22 +22,21 @@ import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ValidatableResponse;
-import io.restassured.specification.RequestSpecification;
 import lombok.NonNull;
 
 public class UsersClient {
-  private final RequestSpecification requestSpecification;
-  private final RestAssuredConfig config;
+  private final RestAssuredClient client;
+
   public UsersClient(URI baseUri, OkapiHeaders defaultHeaders) {
-    requestSpecification = new RequestSpecBuilder()
+    client = new RestAssuredClient(new RequestSpecBuilder()
       .setBaseUri(baseUri)
       .addHeader("X-Okapi-Tenant", defaultHeaders.getTenantId())
       .addHeader("X-Okapi-Token", defaultHeaders.getToken())
       .addHeader("X-Okapi-Url", defaultHeaders.getOkapiUrl())
       .setAccept("application/json, text/plain")
-      .build();
-
-    config = RestAssuredConfig.newConfig()
+      .build(),
+      RestAssuredConfig.newConfig()
+      .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails())
       .objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2)
         .jackson2ObjectMapperFactory((type, s) -> {
           final var mapper = new ObjectMapper();
@@ -46,8 +45,7 @@ public class UsersClient {
           mapper.registerModule(new JavaTimeModule());
 
           return mapper;
-        }))
-      .logConfig(new LogConfig().enableLoggingOfRequestAndResponseIfValidationFails());
+        })));
   }
 
   public User createUser(@NonNull User user) {
@@ -64,8 +62,8 @@ public class UsersClient {
 
   public ValidatableResponse attemptToCreateUser(@NonNull User user) {
     return given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .contentType(JSON)
       .when()
       .body(user)
@@ -81,8 +79,8 @@ public class UsersClient {
 
   public ValidatableResponse attemptToGetUser(String id) {
     return given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .when()
       .get("/users/{id}", Map.of("id", id))
       .then();
@@ -96,8 +94,8 @@ public class UsersClient {
 
   public ValidatableResponse attemptToGetUsers(String cqlQuery) {
     return given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .when()
       .queryParam("query", cqlQuery)
       .get("/users")
@@ -110,8 +108,8 @@ public class UsersClient {
 
   public Users getPatronGroupFacets() {
     return given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .when()
       // Limit must be 1 as request fails with limit 0
       // https://issues.folio.org/browse/UIU-1562  https:/issues.folio.org/browse/RMB-722
@@ -130,8 +128,8 @@ public class UsersClient {
 
   public ValidatableResponse attemptToDeleteUser(String id) {
     return given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .when()
       .delete("/users/{id}", Map.of("id", id))
       .then();
@@ -139,8 +137,8 @@ public class UsersClient {
 
   public void deleteUsers(String cqlQuery) {
     given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .when()
       .queryParam("query", cqlQuery)
       .delete("/users")
@@ -162,8 +160,8 @@ public class UsersClient {
 
   public ValidatableResponse attemptToUpdateUser(String id, @NonNull User user) {
     return given()
-      .config(config)
-      .spec(requestSpecification)
+      .config(client.config)
+      .spec(client.requestSpecification)
       .contentType(JSON)
       .when()
       .body(user)

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -36,18 +36,11 @@ public class UsersClient {
   }
 
   public User getUser(String id) {
-    return attemptToGetUser(id)
-      .statusCode(HTTP_OK)
-      .extract().as(User.class);
+    return client.getRecord("/users/{id}", id, User.class);
   }
 
   public ValidatableResponse attemptToGetUser(String id) {
-    return given()
-      .config(client.config)
-      .spec(client.requestSpecification)
-      .when()
-      .get("/users/{id}", Map.of("id", id))
-      .then();
+    return client.attemptToGetRecord("/users/{id}", id);
   }
 
   public Users getUsers(String cqlQuery) {


### PR DESCRIPTION
*Purpose*

* Remove duplication of code that uses RestAssured to interact with a record collection API.

*Approach*
* Introduce a new class to consolidate the use of RestAssured to
* Move behaviour to the new record collection client class
* Use new client in existing clients that use rest assured
* Extract a configuration class to allow the common specification and config for RestAssured to be used by non record collection API clients