### PR TITLE
Remove argument captor MODUSERS-317

### DIFF
--- a/src/main/java/org/folio/rest/impl/ProxiesForAPI.java
+++ b/src/main/java/org/folio/rest/impl/ProxiesForAPI.java
@@ -1,16 +1,12 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.List;
 import java.util.Map;
+
 import javax.ws.rs.core.Response;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.ProxiesFor;
 import org.folio.rest.jaxrs.model.ProxyforCollection;
@@ -20,6 +16,11 @@ import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.ValidationHelper;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 
 /**
  *
@@ -115,26 +116,22 @@ public class ProxiesForAPI implements Proxiesfor {
     PgUtil.put(PROXY_FOR_TABLE, entity, id, okapiHeaders, vertxContext, PutProxiesforByIdResponse.class, asyncResultHandler);
   }
 
-  Future<Boolean> userAndProxyUserComboExists(
-      String userId,
-      String proxyUserId,
-      PostgresClient postgresClient) {
+  Future<Boolean> userAndProxyUserComboExists(String userId, String proxyUserId,
+    PostgresClient postgresClient) {
 
-    Promise<Boolean> promise = Promise.promise();
     Criteria userCrit = new Criteria().addField(USERID_FIELD_NAME).
       setOperation("=").setVal(userId).setJSONB(true);
+
     Criteria proxyUserCrit = new Criteria().addField(PROXY_USERID_FIELD_NAME).
       setOperation("=").setVal(proxyUserId).setJSONB(true);
+
     Criterion criterion = new Criterion();
     criterion.addCriterion(userCrit, "AND", proxyUserCrit);
-    postgresClient.get(PROXY_FOR_TABLE, ProxiesFor.class, criterion, true, getReply -> {
-      if (getReply.failed()) {
-        promise.fail(getReply.cause());
-      } else {
-        List<ProxiesFor> proxyForList = getReply.result().getResults();
-        promise.complete(! proxyForList.isEmpty());
-      }
-    });
-    return promise.future();
+
+    return postgresClient.get(PROXY_FOR_TABLE, ProxiesFor.class, criterion, true)
+      .map(results -> {
+        List<ProxiesFor> proxyForList = results.getResults();
+        return !proxyForList.isEmpty();
+      });
   }
 }

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -400,7 +400,9 @@ public class UsersAPI implements Users {
   public void postUsersExpireTimer(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
 
-    ExpirationTool.doExpirationForTenant(vertxContext.owner(), okapiHeaders.get("x-okapi-tenant"))
+    final var expirationTool = new ExpirationTool();
+
+    expirationTool.doExpirationForTenant(vertxContext.owner(), okapiHeaders.get("x-okapi-tenant"))
         .onSuccess(res -> asyncResultHandler.handle(
             Future.succeededFuture(PostUsersExpireTimerResponse.respond204())))
         .onFailure(cause -> asyncResultHandler.handle(

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -9,7 +9,10 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
@@ -48,11 +51,9 @@ import org.folio.validate.ValidationServiceImpl;
 import org.z3950.zing.cql.CQLParseException;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.ext.web.RoutingContext;
 
 
@@ -181,7 +182,7 @@ public class UsersAPI implements Users {
       final var addressValidator = new AddressValidator();
 
       if (addressValidator.hasMultipleAddressesWithSameType(entity)) {
-        asyncResultHandler.handle(Future.succeededFuture(
+        asyncResultHandler.handle(succeededFuture(
           PostUsersResponse.respond400WithTextPlain(
             "Users are limited to one address per addresstype")));
         return;
@@ -209,7 +210,7 @@ public class UsersAPI implements Users {
             validatePatronGroup(entity.getPatronGroup(), postgresClient.getValue(), asyncResultHandler,
                     handler -> saveUser(entity, okapiHeaders, asyncResultHandler, vertxContext));
           }
-          return Future.succeededFuture();
+          return succeededFuture();
         })
         .otherwise(e -> {
           if (e instanceof CustomFieldValidationException) {
@@ -218,19 +219,19 @@ public class UsersAPI implements Users {
                 ((CustomFieldValidationException) e).getErrors())));
           } else {
             logger.error(e.getMessage(), e);
-            asyncResultHandler.handle(Future.succeededFuture(
+            asyncResultHandler.handle(succeededFuture(
               PostUsersResponse.respond500WithTextPlain(
                 messages.getMessage(lang, MessageConsts.InternalServerError))));
           }
           return null;
         }).onFailure(e -> {
           logger.error(e.getMessage(), e);
-          asyncResultHandler.handle(Future.succeededFuture(
+          asyncResultHandler.handle(succeededFuture(
             PostUsersResponse.respond500WithTextPlain(e.getMessage())));
         });
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
-      asyncResultHandler.handle(Future.succeededFuture(
+      asyncResultHandler.handle(succeededFuture(
         PostUsersResponse.respond500WithTextPlain(e.getMessage())));
     }
   }
@@ -338,7 +339,7 @@ public class UsersAPI implements Users {
       Context vertxContext) {
 
     try {
-      Future.succeededFuture()
+      succeededFuture()
         .compose(o -> {
           removeCustomFieldIfEmpty(entity);
           return new ValidationServiceImpl(vertxContext)
@@ -349,27 +350,27 @@ public class UsersAPI implements Users {
           final var addressValidator = new AddressValidator();
 
           if (addressValidator.hasMultipleAddressesWithSameType(entity)) {
-            asyncResultHandler.handle(Future.succeededFuture(
+            asyncResultHandler.handle(succeededFuture(
               PostUsersResponse.respond400WithTextPlain("Users are limited to one address per addresstype")));
-            return Future.succeededFuture();
+            return succeededFuture();
           }
           if (!userId.equals(entity.getId())) {
-            asyncResultHandler.handle(Future.succeededFuture(
+            asyncResultHandler.handle(succeededFuture(
               PutUsersByUserIdResponse.respond400WithTextPlain("You cannot change the value of the id field")));
-            return Future.succeededFuture();
+            return succeededFuture();
           }
           PostgresClient postgresClient = PgUtil.postgresClient(vertxContext, okapiHeaders);
 
           return checkAllAddressTypesValid(entity, postgresClient)
             .compose(result -> {
               if (Boolean.FALSE.equals(result)) {
-                asyncResultHandler.handle(Future.succeededFuture(
+                asyncResultHandler.handle(succeededFuture(
                   PostUsersResponse.respond400WithTextPlain("All addresses types defined for users must be existing")));
               } else {
                 validatePatronGroup(entity.getPatronGroup(), postgresClient, asyncResultHandler,
                   handler -> updateUser(entity, okapiHeaders, asyncResultHandler, vertxContext));
               }
-              return Future.succeededFuture();
+              return succeededFuture();
             });
         })
         .otherwise(e -> {
@@ -379,19 +380,19 @@ public class UsersAPI implements Users {
               PostUsersResponse.respond422WithApplicationJson(
                 ((CustomFieldValidationException) e).getErrors())));
           } else {
-            asyncResultHandler.handle(Future.succeededFuture(
+            asyncResultHandler.handle(succeededFuture(
               PutUsersByUserIdResponse.respond500WithTextPlain(
                 messages.getMessage(lang, MessageConsts.InternalServerError))));
           }
           return null;
         }).onFailure(e -> {
           logger.error(e.getMessage(), e);
-          asyncResultHandler.handle(Future.succeededFuture(
+          asyncResultHandler.handle(succeededFuture(
               PutUsersByUserIdResponse.respond500WithTextPlain(e.getMessage())));
         });
     } catch (Exception e) {
       logger.error(e.getMessage(), e);
-      asyncResultHandler.handle(Future.succeededFuture(
+      asyncResultHandler.handle(succeededFuture(
           PutUsersByUserIdResponse.respond500WithTextPlain(e.getMessage())));
     }
   }
@@ -405,9 +406,9 @@ public class UsersAPI implements Users {
 
     expirationTool.doExpirationForTenant(vertxContext.owner(), okapiHeaders.get("x-okapi-tenant"))
         .onSuccess(res -> asyncResultHandler.handle(
-            Future.succeededFuture(PostUsersExpireTimerResponse.respond204())))
+            succeededFuture(PostUsersExpireTimerResponse.respond204())))
         .onFailure(cause -> asyncResultHandler.handle(
-            Future.succeededFuture(PostUsersExpireTimerResponse.respond500WithTextPlain(cause.getMessage()))));
+            succeededFuture(PostUsersExpireTimerResponse.respond500WithTextPlain(cause.getMessage()))));
   }
 
   private void updateUser(User entity, Map<String, String> okapiHeaders,
@@ -451,14 +452,14 @@ public class UsersAPI implements Users {
 
     if (patronGroupId == null) {
       //allow null patron groups so that they can be added after a record is created
-      handler.handle(io.vertx.core.Future.succeededFuture(1));
+      handler.handle(succeededFuture(1));
     } else {
       postgresClient.getById(UserGroupAPI.GROUP_TABLE, patronGroupId, check -> {
         if (check.succeeded()) {
           if (check.result() == null) {
-            handler.handle(io.vertx.core.Future.succeededFuture(0));
+            handler.handle(succeededFuture(0));
           } else {
-            handler.handle(io.vertx.core.Future.succeededFuture(1));
+            handler.handle(succeededFuture(1));
           }
         } else {
           Throwable t = check.cause();
@@ -467,7 +468,7 @@ public class UsersAPI implements Users {
           if (t.getLocalizedMessage().contains("uuid")) {
             retCode = 0;
           }
-          handler.handle(io.vertx.core.Future.succeededFuture(retCode));
+          handler.handle(succeededFuture(retCode));
         }
       });
     }
@@ -492,15 +493,15 @@ public class UsersAPI implements Users {
           patronGroupId +
           ". Patron group not found";
         logger.error(message);
-        asyncResultHandler.handle(Future.succeededFuture(
+        asyncResultHandler.handle(succeededFuture(
           PostUsersResponse.respond400WithTextPlain(
             message)));
       } else if (res == -1) {
-        asyncResultHandler.handle(Future.succeededFuture(
+        asyncResultHandler.handle(succeededFuture(
           PostUsersResponse
             .respond500WithTextPlain("")));
       } else {
-        onSuccess.handle(Future.succeededFuture());
+        onSuccess.handle(succeededFuture());
       }
     });
   }
@@ -511,7 +512,6 @@ public class UsersAPI implements Users {
   }
 
   Future<Boolean> checkAddressTypeValid(String addressTypeId, PostgresClient postgresClient) {
-
     final var criterion = new Criterion(
       new Criteria().addField(AddressTypeAPI.ID_FIELD_NAME)
         .setJSONB(false).setOperation("=").setVal(addressTypeId));
@@ -526,42 +526,29 @@ public class UsersAPI implements Users {
   }
 
   Future<Boolean> checkAllAddressTypesValid(User user, PostgresClient postgresClient) {
-    Promise<Boolean> promise = Promise.promise();
-
     List<Future<Boolean>> futureList = new ArrayList<>();
 
     if (user.getPersonal() == null || user.getPersonal().getAddresses() == null) {
-      promise.complete(true);
-      return promise.future();
+      return succeededFuture(true);
     }
 
-    for (Address address : user.getPersonal().getAddresses()) {
-      String addressTypeId = address.getAddressTypeId();
+    final var addressTypes = user.getPersonal().getAddresses()
+      .stream()
+      .map(Address::getAddressTypeId)
+      .collect(Collectors.toList());
 
-      // If any address type ID is not provided, fail immediately
-      if (addressTypeId == null) {
-        promise.complete(false);
-        return promise.future();
-      }
-
-      futureList.add(checkAddressTypeValid(addressTypeId, postgresClient));
+    // If any address type ID is not provided, fail immediately
+    if (addressTypes.stream().anyMatch(Objects::isNull)) {
+      return Future.succeededFuture(false);
     }
 
-    CompositeFuture compositeFuture = GenericCompositeFuture.all(futureList);
-    compositeFuture.onComplete(res -> {
-      if (res.failed()) {
-        promise.fail(res.cause());
-        return;
-      }
-      for (Future<Boolean> f : futureList) {
-        if (Boolean.FALSE.equals(f.result())) {
-          promise.complete(false);
-          return;
-        }
-      }
-      promise.complete(true);
-    });
-    return promise.future();
+    addressTypes.forEach(addressTypeId -> futureList.add(
+      checkAddressTypeValid(addressTypeId, postgresClient)));
+
+    return GenericCompositeFuture.all(futureList)
+      .map(res -> futureList.stream()
+        .map(Future::result)
+        .allMatch(Predicate.isEqual(true)));
   }
 
   private static Map<String, Object> getCustomFields(User entity) {

--- a/src/main/java/org/folio/rest/utils/ExpirationTool.java
+++ b/src/main/java/org/folio/rest/utils/ExpirationTool.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
@@ -43,6 +44,11 @@ public final class ExpirationTool {
       CQL2PgJSON cql2pgJson = new CQL2PgJSON(List.of(TABLE_NAME_USERS+".jsonb"));
       CQLWrapper cqlWrapper = new CQLWrapper(cql2pgJson, query);
       String[] fieldList = {"*"};
+      
+      if (StringUtils.isEmpty(tenant)) {
+        return Future.failedFuture(
+          new IllegalArgumentException("Cannot expire users for undefined tenant"));
+      }
 
       PostgresClient pgClient = postgresClientFactory.apply(vertx, tenant);
 

--- a/src/main/java/org/folio/rest/utils/ExpirationTool.java
+++ b/src/main/java/org/folio/rest/utils/ExpirationTool.java
@@ -27,11 +27,7 @@ public final class ExpirationTool {
   /** PostgresClient::getInstance, or some other method for unit testing */
   static BiFunction<Vertx, String, PostgresClient> postgresClient = PostgresClient::getInstance;
 
-  private ExpirationTool() {
-    throw new UnsupportedOperationException("Cannot instantiate utility class.");
-  }
-
-  public static Future<Integer> doExpirationForTenant(Vertx vertx, String tenant) {
+  public Future<Integer> doExpirationForTenant(Vertx vertx, String tenant) {
     Promise<Integer> promise = Promise.promise();
     try {
       String nowDateString = ZonedDateTime.now().format(ISO_INSTANT);
@@ -77,7 +73,7 @@ public final class ExpirationTool {
     return promise.future();
   }
 
-  static Future<Void> disableUser(Vertx vertx, String tenant, User user) {
+  Future<Void> disableUser(Vertx vertx, String tenant, User user) {
     logger.info("Disabling expired user with id {} for tenant {}", user.getId(), tenant);
     user.setActive(Boolean.FALSE);
     Promise<Void> promise = Promise.promise();

--- a/src/test/java/org/folio/rest/impl/ProxiesForAPITest.java
+++ b/src/test/java/org/folio/rest/impl/ProxiesForAPITest.java
@@ -5,42 +5,27 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import org.folio.rest.jaxrs.model.ProxiesFor;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.persist.interfaces.Results;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 
 class ProxiesForAPITest {
   @Test
   void userAndProxyUserComboExistsCanHandlePostgresClientFailure() {
     var postgresClient = mock(PostgresClient.class);
 
-    doAnswer((Answer<Void>) ProxiesForAPITest::provideFailedFutureToHandler)
-    .when(postgresClient).get(anyString(), any(), any(Criterion.class), anyBoolean(), any());
+    when(postgresClient.get(anyString(), any(), any(Criterion.class), anyBoolean()))
+      .thenReturn(Future.failedFuture(new RuntimeException("my exception")));
 
     var future = new ProxiesForAPI()
-      .userAndProxyUserComboExists("someUserId", "someProxyUserId", postgresClient);
+      .userAndProxyUserComboExists("someUserId", "someProxyUserId",
+        postgresClient);
 
     assertThat(future.cause().getMessage(), is("my exception"));
-  }
-
-  @Nullable
-  private static Void provideFailedFutureToHandler(InvocationOnMock invocationOnMock) {
-    final Handler<AsyncResult<Results<ProxiesFor>>> handler = invocationOnMock.getArgument(4);
-
-    handler.handle(Future.failedFuture(new RuntimeException("my exception")));
-
-    return null;
   }
 }

--- a/src/test/java/org/folio/rest/impl/ProxiesForAPITest.java
+++ b/src/test/java/org/folio/rest/impl/ProxiesForAPITest.java
@@ -5,15 +5,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import org.folio.rest.jaxrs.model.ProxiesFor;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.interfaces.Results;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -22,12 +24,23 @@ import io.vertx.core.Handler;
 class ProxiesForAPITest {
   @Test
   void userAndProxyUserComboExistsCanHandlePostgresClientFailure() {
-    PostgresClient postgresClient = mock(PostgresClient.class);
-    Future<Boolean> future = new ProxiesForAPI()
-        .userAndProxyUserComboExists("someUserId", "someProxyUserId", postgresClient);
-    ArgumentCaptor<Handler<AsyncResult<Results<ProxiesFor>>>> handlerCaptor = ArgumentCaptor.forClass(Handler.class);
-    verify(postgresClient).get(anyString(), any(), any(Criterion.class), anyBoolean(), handlerCaptor.capture());
-    handlerCaptor.getValue().handle(Future.failedFuture(new RuntimeException("my exception")));
+    var postgresClient = mock(PostgresClient.class);
+
+    doAnswer((Answer<Void>) ProxiesForAPITest::provideFailedFutureToHandler)
+    .when(postgresClient).get(anyString(), any(), any(Criterion.class), anyBoolean(), any());
+
+    var future = new ProxiesForAPI()
+      .userAndProxyUserComboExists("someUserId", "someProxyUserId", postgresClient);
+
     assertThat(future.cause().getMessage(), is("my exception"));
+  }
+
+  @Nullable
+  private static Void provideFailedFutureToHandler(InvocationOnMock invocationOnMock) {
+    final Handler<AsyncResult<Results<ProxiesFor>>> handler = invocationOnMock.getArgument(4);
+
+    handler.handle(Future.failedFuture(new RuntimeException("my exception")));
+
+    return null;
   }
 }

--- a/src/test/java/org/folio/rest/impl/ProxiesForAPITest.java
+++ b/src/test/java/org/folio/rest/impl/ProxiesForAPITest.java
@@ -8,6 +8,9 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.UUID;
+
+import org.folio.rest.jaxrs.model.ProxiesFor;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.junit.jupiter.api.Test;
@@ -22,9 +25,12 @@ class ProxiesForAPITest {
     when(postgresClient.get(anyString(), any(), any(Criterion.class), anyBoolean()))
       .thenReturn(Future.failedFuture(new RuntimeException("my exception")));
 
+    final var proxyRelationship = new ProxiesFor()
+      .withUserId(UUID.randomUUID().toString())
+      .withProxyUserId(UUID.randomUUID().toString());
+
     var future = new ProxiesForAPI()
-      .userAndProxyUserComboExists("someUserId", "someProxyUserId",
-        postgresClient);
+      .userAndProxyUserComboExists(proxyRelationship, postgresClient);
 
     assertThat(future.cause().getMessage(), is("my exception"));
   }

--- a/src/test/java/org/folio/rest/impl/UsersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPITest.java
@@ -197,8 +197,7 @@ class UsersAPITest {
     final var future = new UsersAPI()
       .checkAddressTypeValid("someAddressTypeId", postgresClient);
 
-    future.onComplete(context.failing(e ->
-      context.verify(() -> handler.handle(future.cause()))));
+    future.onComplete(context.failing(handler));
   }
 }
 

--- a/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
+++ b/src/test/java/org/folio/rest/utils/ExpirationToolTest.java
@@ -6,9 +6,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
@@ -19,12 +19,8 @@ import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.persist.interfaces.Results;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxExtension;
@@ -54,7 +50,7 @@ class ExpirationToolTest {
     final var expirationTool = new ExpirationTool((v, t) -> postgresClient);
 
     doThrow(new RuntimeException("pg"))
-      .when(postgresClient).get(anyString(), any(), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), any(Handler.class));
+      .when(postgresClient).get(anyString(), any(), any(), any(CQLWrapper.class), anyBoolean());
 
     final var future = expirationTool.doExpirationForTenant(vertx, "someTenant");
 
@@ -69,9 +65,8 @@ class ExpirationToolTest {
     final var postgresClient = mock(PostgresClient.class);
     final var expirationTool = new ExpirationTool((v, t) -> postgresClient);
 
-    doAnswer((Answer<Void>) invocationOnMock -> provideFailedFutureToHandler(
-      invocationOnMock, 6))
-      .when(postgresClient).get(anyString(), any(), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), any(Handler.class));
+    when(postgresClient.get(anyString(), any(), any(), any(CQLWrapper.class), anyBoolean()))
+      .thenReturn(Future.failedFuture("Database shut down for holidays"));
 
     final var future = expirationTool.doExpirationForTenant(vertx, "someTenant");
 
@@ -86,8 +81,12 @@ class ExpirationToolTest {
     final var postgresClient = mock(PostgresClient.class);
     final var expirationTool = new ExpirationTool((v, t) -> postgresClient);
 
-    doAnswer((Answer<Void>) this::provideSuccessFutureToHandler)
-      .when(postgresClient).get(anyString(), any(), any(), any(CQLWrapper.class), anyBoolean(), anyBoolean(), any(Handler.class));
+    var results = new Results<>();
+
+    results.setResults(Collections.emptyList());
+
+    when(postgresClient.get(anyString(), any(), any(), any(CQLWrapper.class), anyBoolean()))
+      .thenReturn(Future.succeededFuture(results));
 
     final var future = expirationTool.doExpirationForTenant(vertx, "someTenant");
 
@@ -111,41 +110,11 @@ class ExpirationToolTest {
     final var postgresClient = mock(PostgresClient.class);
     final var expirationTool = new ExpirationTool((v, t) -> postgresClient);
 
-    doAnswer((Answer<Void>) invocationOnMock -> provideFailedFutureToHandler(
-      invocationOnMock, 3))
-      .when(postgresClient).update(anyString(), any(User.class), any(), any(Handler.class));
+    when(postgresClient.update(anyString(), any(User.class), any()))
+      .thenReturn(Future.failedFuture("Database shut down for holidays"));
 
     var future = expirationTool.disableUser(vertx, "myTenant", new User());
 
     assertThat(future.cause().getMessage(), is("Database shut down for holidays"));
-  }
-
-  private static Void provideFailedFutureToHandler(InvocationOnMock invocationOnMock,
-    int handlerArgumentIndex) {
-
-    provideFutureToHandler(invocationOnMock, handlerArgumentIndex,
-      Future.failedFuture("Database shut down for holidays"));
-
-    return null;
-  }
-
-  private Void provideSuccessFutureToHandler(InvocationOnMock invocationOnMock) {
-    var results = new Results<User>();
-
-    results.setResults(Collections.emptyList());
-
-    provideFutureToHandler(invocationOnMock, 6,
-      Future.succeededFuture(results));
-
-    return null;
-  }
-
-  private static <T> void provideFutureToHandler(InvocationOnMock invocationOnMock,
-    int handlerArgumentIndex, Future<T> results) {
-
-    final Handler<AsyncResult<T>> handler = invocationOnMock.getArgument(
-      handlerArgumentIndex);
-
-    handler.handle(results);
   }
 }


### PR DESCRIPTION
*Purpose*

Removing warnings related to the use of argument capture. The warnings are irritating and the approach makes the tests harder to follow as the arrangement of these expectations are done _after_ the production code is executed.

As part of this work I discovered that there were _no tests_ for successful expiration of users.

*Approach*
* Add integration tests for disabling expired users
* Change the existing tests to use `doAnswer` in order to arrange expectations prior to execution
* Change the existing tests and production code to use future rather than handler based methods from PostgresClient