### PR TITLE
Address missing addressType should return 400. MODUSERS-232

### DIFF
--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -550,6 +550,11 @@ public class UsersAPI implements Users {
     }
     for (Address address : user.getPersonal().getAddresses()) {
       String addressTypeId = address.getAddressTypeId();
+      if (addressTypeId == null) {
+        promise.complete(false);
+        return promise.future();
+      }
+
       Future<Boolean> addressTypeExistsFuture = checkAddressTypeValid(addressTypeId, vertxContext, postgresClient);
       futureList.add(addressTypeExistsFuture);
     }

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -210,6 +210,31 @@ class UsersAPIIT {
       is("User with this id already exists"));
   }
 
+  @Test
+  void cannotCreateUserWithAddressButNoAddressType() {
+    final var addressWithoutId = Address.builder().build();
+    final var homeAddressType = addressTypesClient.createAddressType(
+      AddressType.builder()
+        .addressType("Home")
+        .build());
+    final var homeAddress = Address.builder()
+      .addressTypeId(homeAddressType.getId()).build();
+
+    final var userToCreate = User.builder()
+      .username("juliab")
+      .active(true)
+      .personal(Personal.builder()
+        .firstName("julia")
+        .preferredFirstName("jules")
+        .lastName("brockhurst")
+        .addresses(List.of(homeAddress, addressWithoutId))
+        .build())
+      .tags(TagList.builder().tagList(List.of("foo", "bar")).build())
+      .build();
+
+    usersClient.attemptToCreateUser(userToCreate)
+      .statusCode(is(400));
+  }
 
   @Test
   void canUpdateAUser() {


### PR DESCRIPTION
*Purpose*
POST or PUT user without addressTypeId should not silent throw an HTTP 500 and should instead throw an HTTP 4XX.
https://issues.folio.org/browse/MODUSERS-232

*Approach*
Add a check for each address to see if `addressTypeId` is defined.
If it is not defined, then immediately set promise to FALSE and bail.
The caller already has the necessary code in place to return the appropriate 4XX for when FALSE is returned.
