### PR TITLE
MODUSERS-212: Make AddressTypeID field required for addresses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 19.0.0 IN-PROGRESS
 
 * Made AddressTypeId field required for all user addresses (MODUSERS-212)
+* Provides `users 16.0`
 
 ## 18.3.0 2022-06-13
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 19.0.0 IN-PROGRESS
+
+* Made AddressTypeId field required for all user addresses (MODUSERS-212)
+
 ## 18.3.0 2022-06-13
 
 * Added index to search by perferredFirstName (MODUSERS-310)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>18.4.0-SNAPSHOT</version>
+  <version>19.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>

--- a/ramls/userdata.json
+++ b/ramls/userdata.json
@@ -135,6 +135,7 @@
                 "type": "boolean"
               }
             },
+            "required":["addressTypeId"],
             "additionalProperties": false
           }
         },

--- a/ramls/userdata.json
+++ b/ramls/userdata.json
@@ -135,7 +135,9 @@
                 "type": "boolean"
               }
             },
-            "required":["addressTypeId"],
+            "required":[
+              "addressTypeId"
+            ],
             "additionalProperties": false
           }
         },

--- a/ramls/users.raml
+++ b/ramls/users.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Users
-version: v15.5
+version: v16.0
 baseUri: http://github.com/org/folio/mod-users
 
 documentation:

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -233,7 +233,7 @@ class UsersAPIIT {
       .build();
 
     usersClient.attemptToCreateUser(userToCreate)
-      .statusCode(is(400));
+      .statusCode(is(422));
   }
 
   @Test


### PR DESCRIPTION
I was not sure if I needed to increment the interface version a full number as well.

The api now seems to issue a 422 error when an addressTypeId is not provided.
I'm not sure if that's correct-shouldn't it be a 400 error?