### PR TITLE
MODUSERS-212: Make addresstypeid property required for addresses

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "users",
-      "version": "15.5",
+      "version": "16.0",
       "handlers" : [
         {
           "methods": [ "GET" ],

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -503,11 +503,6 @@ public class UsersAPI implements Users {
       .map(Address::getAddressTypeId)
       .collect(Collectors.toList());
 
-    // If any address type ID is not provided, fail immediately
-    if (addressTypes.stream().anyMatch(Objects::isNull)) {
-      return Future.succeededFuture(false);
-    }
-
     addressTypes.forEach(addressTypeId -> futureList.add(
       checkAddressTypeValid(addressTypeId, postgresClient)));
 


### PR DESCRIPTION
I neglected to increment the version number in the descriptor file.

Edit:  I've also removed the check for a null addresstypeId, as this is not needed,  but I have
left other address-related checks in place, as they check for uniqueness and that the id
provided actually exists in the system.