### PR TITLE
MODUSERS-324: Don't reuse tenant in integration tests

### DIFF
--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -41,7 +41,7 @@ public class CustomFieldIT {
   @BeforeAll
   @SneakyThrows
   public static void beforeAll(Vertx vertx, VertxTestContext context) {
-    final var tenant = "diku";
+    final var tenant = "customfieldit";
     final var token = new FakeTokenGenerator().generateToken();
 
     PostgresClient.setPostgresTester(new PostgresTesterContainer());

--- a/src/test/java/org/folio/moduserstest/ExpirationIT.java
+++ b/src/test/java/org/folio/moduserstest/ExpirationIT.java
@@ -31,6 +31,7 @@ import lombok.SneakyThrows;
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 20, unit = SECONDS)
 class ExpirationIT {
+  private final static String TENANT = "expirationit";
   private static UsersClient usersClient;
   private static ExpirationClient expirationClient;
 
@@ -42,7 +43,7 @@ class ExpirationIT {
     int port = NetworkUtils.nextFreePort();
 
     final var okapiUrl = new OkapiUrl( "http://localhost:" + port);
-    final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
+    final var headers = new OkapiHeaders(okapiUrl, TENANT, "token");
 
     usersClient = new UsersClient(okapiUrl, headers);
     expirationClient = new ExpirationClient(okapiUrl, headers);
@@ -73,7 +74,7 @@ class ExpirationIT {
       .expirationDate(ZonedDateTime.now().minusDays(15))
       .build());
 
-    expirationClient.attemptToTriggerExpiration("diku")
+    expirationClient.attemptToTriggerExpiration(TENANT)
       .statusCode(is(HTTP_NO_CONTENT));
 
     final var firstFetchedUser = usersClient.getUser(firstExpiredUser.getId());
@@ -93,7 +94,7 @@ class ExpirationIT {
       .expirationDate(ZonedDateTime.now().plusHours(3))
       .build());
 
-    expirationClient.attemptToTriggerExpiration("diku")
+    expirationClient.attemptToTriggerExpiration(TENANT)
       .statusCode(is(HTTP_NO_CONTENT));
 
     final var fetchedUser = usersClient.getUser(unexpiredUser.getId());

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -48,7 +48,8 @@ class GroupIT {
     int port = NetworkUtils.nextFreePort();
 
     final var okapiUrl = new OkapiUrl( "http://localhost:" + port);
-    final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
+    final var tenant = "groupit";
+    final var headers = new OkapiHeaders(okapiUrl, tenant, "token");
 
     groupsClient = new GroupsClient(okapiUrl, headers);
     usersClient = new UsersClient(okapiUrl, headers);

--- a/src/test/java/org/folio/moduserstest/ProxyRelationshipsIT.java
+++ b/src/test/java/org/folio/moduserstest/ProxyRelationshipsIT.java
@@ -51,7 +51,8 @@ class ProxyRelationshipsIT {
     int port = NetworkUtils.nextFreePort();
 
     final var okapiUrl = new OkapiUrl( "http://localhost:" + port);
-    final var headers = new OkapiHeaders(okapiUrl, "diku", "diku");
+    final var tenant = "proxyrelationshipsit";
+    final var headers = new OkapiHeaders(okapiUrl, tenant, "token");
 
     proxiesClient = new ProxiesClient(okapiUrl, headers);
 

--- a/src/test/java/org/folio/rest/impl/AddressTypesIT.java
+++ b/src/test/java/org/folio/rest/impl/AddressTypesIT.java
@@ -49,7 +49,7 @@ class AddressTypesIT {
   @BeforeAll
   @SneakyThrows
   static void beforeAll(Vertx vertx, VertxTestContext context) {
-    final var tenant = "users_integration_tests";
+    final var tenant = "addresstypesit";
     final var token = new FakeTokenGenerator().generateToken();
 
     PostgresClient.setPostgresTester(new PostgresTesterContainer());

--- a/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
+++ b/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
@@ -37,7 +37,7 @@ class ReferenceAndSampleDataIT {
   @BeforeAll
   @SneakyThrows
   static void beforeAll(Vertx vertx, VertxTestContext context) {
-    final var tenant = "users_integration_tests";
+    final var tenant = "referenceandsampledatait";
     final var token = new FakeTokenGenerator().generateToken();
 
     PostgresClient.setPostgresTester(new PostgresTesterContainer());

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -51,7 +51,7 @@ class UsersAPIIT {
   @BeforeAll
   @SneakyThrows
   static void beforeAll(Vertx vertx, VertxTestContext context) {
-    final var tenant = "users_integration_tests";
+    final var tenant = "usersapiit";
     final var token = new FakeTokenGenerator().generateToken();
 
     PostgresClient.setPostgresTester(new PostgresTesterContainer());


### PR DESCRIPTION
Locally I always get

```
[ERROR]   ReferenceAndSampleDataIT.manySampleUsersAreCreated:84
Expected: is <303>
     but: was <305>
```

when doing `mvn install`.

The two unexpected users have been created by some other test.

Solution:

Use a different tenant for each integration test to make them independent.