### PR TITLE
MODUSERS-325: AddressTypesIT fails when locale is not English

### DIFF
--- a/src/test/java/org/folio/rest/impl/AddressTypesIT.java
+++ b/src/test/java/org/folio/rest/impl/AddressTypesIT.java
@@ -96,8 +96,10 @@ class AddressTypesIT {
       .extract().as(ValidationErrors.class);
 
     assertThat(errors.getErrors(), hasSize(1));
-    assertThat(errors.getErrors().get(0).getMessage(),
-      is("must not be null"));
+    // message gets translated when running "LANG=de_DE.UTF-8 mvn install",
+    // parameters stay the same
+    assertThat(errors.getErrors().get(0).getParameters().toString(),
+        is("[Parameter(key=addressType, value=null)]"));
   }
 
   @Test


### PR DESCRIPTION
"LANG=de_DE.UTF-8 mvn install" fails with

```
[ERROR]   AddressTypesIT.cannotCreateAnAddressTypeWithoutAName:99
Expected: is "must not be null"
     but: was "darf nicht null sein"
```

Fix: Rewrite the test without using the translated message.