### PR TITLE
MODUSERS-326: Vert.x 4.3.3, Spring 5.4.20 fixing vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,12 +505,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <raml-module-builder.version>34.0.0</raml-module-builder.version>
-    <vertx.version>4.3.1</vertx.version>
+    <raml-module-builder.version>34.0.2</raml-module-builder.version>
+    <vertx.version>4.3.3</vertx.version>
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.8.1</junit.version>
-    <folio-service-tools.version>1.8.0</folio-service-tools.version>
-    <folio-custom-fields.version>1.7.0</folio-custom-fields.version>
+    <folio-service-tools.version>1.9.0</folio-service-tools.version>
+    <folio-custom-fields.version>1.8.0</folio-custom-fields.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
   </properties>
 </project>


### PR DESCRIPTION
Upgrade vertx from 4.3.1 to 4.3.3 fixing disabled SSL: https://github.com/vert-x3/wiki/wiki/4.3.2-Release-Notes

Upgrade RMB from 34.0.0 to 34.0.2 to match the new Vert.x version.
Upgrade folio-service-tools from 1.7.0 to 1.8.0 to match the new RMB version.

Upgrade folio-custom-fields from 1.8.0 to 1.9.0, this upgrades spring-beans, spring-expression and spring-context from 5.3.16 to 5.3.20 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2022-22970 , https://nvd.nist.gov/vuln/detail/CVE-2022-22950 , and Improper Handling of Case Sensitivity https://nvd.nist.gov/vuln/detail/CVE-2022-22968