### PR TITLE
[MODUSERS-347] - Implement sending USER_CREATED event using transactional outbox pattern

### DIFF
--- a/ramls/userEvent.json
+++ b/ramls/userEvent.json
@@ -16,9 +16,9 @@
         "Delete"
       ]
     },
-    "userId": {
-      "description": "UUID of the user",
-      "$ref": "raml-util/schemas/uuid.schema"
+    "tenantId": {
+      "description": "The name of the user's tenant",
+      "type": "string"
     },
     "performedBy": {
       "description": "UUID of the user who performed the action",
@@ -34,7 +34,7 @@
       "format": "date-time",
       "type": "string"
     },
-    "userSnapshot": {
+    "userDto": {
       "description": "Full snapshot of the user",
       "type": "object",
       "$ref": "userdata.json"

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -14,7 +14,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 import java.util.UUID;
@@ -31,6 +30,7 @@ import org.folio.support.ValidationErrors;
 import org.folio.support.http.AddressTypesClient;
 import org.folio.support.http.GroupsClient;
 import org.folio.support.http.UsersClient;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,6 +86,8 @@ class UsersAPIIT extends AbstractRestTest {
     var userEvent = Json.decodeValue(usersList.iterator().next(), UserEvent.class);
     var userFromEventPayload = userEvent.getUser();
 
+    assertEquals(TENANT_NAME, userEvent.getTenantId());
+
     assertEquals(1, usersList.size());
     assertThat(UserEvent.Action.CREATE, is(userEvent.getAction()));
 
@@ -105,8 +107,7 @@ class UsersAPIIT extends AbstractRestTest {
     assertThat(userFromEventPayload.getTags().getTagList(),
       containsInAnyOrder("foo", "bar"));
 
-    assertNotNull(userFromEventPayload.getMetadata().getCreatedDate());
-    assertNotNull(userFromEventPayload.getMetadata().getUpdatedDate());
+    Assertions.assertNull(userFromEventPayload.getMetadata());
     assertThat(createdUser.getMetadata().getCreatedDate(), is(notNullValue()));
     assertThat(createdUser.getMetadata().getUpdatedDate(), is(notNullValue()));
   }


### PR DESCRIPTION

- Updated the userEvent.json RAML file to include the tenantId property, which represents the name of the user's tenant.
- Refactored the userSnapshot property to userDto for consistency and improved readability.
- Refactored the sendUserCreatedEvent method to accept the tenantId as a parameter in addition to the user and eventAction parameters.
- Updated the getUserEvent method to include the tenantId in the UserEvent object.
- Removed redundant code related to setting userId, actionDate, and user properties based on eventAction.