### PR TITLE
[MODUSERS-354] Consume Primary Affiliation Created event and store in local persistence

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,7 @@ buildMvn {
   doDocker = {
     buildJavaDocker {
       publishMaster = tue
-      healthChk = true
-      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'
+      //healthChk for /admin/health in InstallUpgradeIT.java
     }
   }
 }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -459,7 +459,8 @@
         "patron-pin.set",
         "patron-pin.delete",
         "patron-pin.validate",
-        "user-tenants.collection.get"      ]
+        "user-tenants.collection.get"
+      ]
     },{
       "permissionName": "user-settings.custom-fields.collection.get",
       "displayName": "User Custom Fields - get collection",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -215,6 +215,17 @@
       ]
     },
     {
+      "id": "user-tenants",
+      "version": "1.0",
+      "handlers" : [
+        {
+          "methods": [ "GET" ],
+          "pathPattern": "/user-tenants",
+          "permissionsRequired": [ "user-tenants.collection.get" ]
+        }
+      ]
+    },
+    {
       "id": "_tenant",
       "version": "2.0",
       "interfaceType" : "system",
@@ -408,6 +419,11 @@
       "description": "Permission to validate patron pin"
     },
     {
+      "permissionName" : "user-tenants.collection.get",
+      "displayName" : "Permission to retrieve primary affiliation for the user",
+      "description" : "Get a list of user-tenants records"
+    },
+    {
       "permissionName" : "users.all",
       "displayName" : "users all",
       "description" : "All permissions for the mod-users module",
@@ -442,8 +458,8 @@
         "departments.item.delete",
         "patron-pin.set",
         "patron-pin.delete",
-        "patron-pin.validate"
-      ]
+        "patron-pin.validate",
+        "user-tenants.collection.get"      ]
     },{
       "permissionName": "user-settings.custom-fields.collection.get",
       "displayName": "User Custom Fields - get collection",

--- a/ramls/examples/userTenant.sample
+++ b/ramls/examples/userTenant.sample
@@ -1,0 +1,6 @@
+{
+  "id": "0d6a9156-25b9-4bee-ab4d-dbb31afba0bd",
+  "userId": "11484f66-5121-43ea-81e7-6d9e3711495f",
+  "username": "folio_user",
+  "tenantId": "sfs000"
+}

--- a/ramls/examples/userTenantCollection.sample
+++ b/ramls/examples/userTenantCollection.sample
@@ -1,0 +1,11 @@
+{
+  "userTenants": [
+    {
+      "id": "0d6a9156-25b9-4bee-ab4d-dbb31afba0bd",
+      "userId": "11484f66-5121-43ea-81e7-6d9e3711495f",
+      "username": "folio_user",
+      "tenantId": "sfs000"
+    }
+  ],
+  "totalRecords": 1
+}

--- a/ramls/userTenant.json
+++ b/ramls/userTenant.json
@@ -18,14 +18,6 @@
     "tenantId": {
       "description": "UUID of the tenant",
       "type": "string"
-    },
-    "tenantName": {
-      "description": "The tenant name",
-      "type": "string"
-    },
-    "isPrimary": {
-      "description": "A flag to determine if a affiliation primary",
-      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/ramls/userTenant.json
+++ b/ramls/userTenant.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "User tenant",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "UUID of the user tenant",
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
+    "userId": {
+      "description": "UUID of the user",
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
+    "userName": {
+      "description": "The user name",
+      "type": "string"
+    },
+    "tenantId": {
+      "description": "UUID of the tenant",
+      "type": "string"
+    },
+    "tenantName": {
+      "description": "The tenant name",
+      "type": "string"
+    },
+    "isPrimary": {
+      "description": "A flag to determine if a affiliation primary",
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "userId",
+    "tenantId"
+  ]
+}

--- a/ramls/userTenant.json
+++ b/ramls/userTenant.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "User tenant",
+  "description": "Primary tenant of a user used for single-sign-on",
   "type": "object",
   "properties": {
     "id": {
@@ -16,7 +16,7 @@
       "type": "string"
     },
     "tenantId": {
-      "description": "UUID of the tenant",
+      "description": "Primary tenant of the user for single-sign-on",
       "type": "string"
     }
   },

--- a/ramls/userTenantCollection.json
+++ b/ramls/userTenantCollection.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Collection of user tenants",
+  "properties": {
+    "userTenants": {
+      "description": "List of user tenants",
+      "type": "array",
+      "id": "userTenants",
+      "items": {
+        "type": "object",
+        "$ref": "userTenant.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "userTenants",
+    "totalRecords"
+  ]
+}

--- a/ramls/userTenantCollection.json
+++ b/ramls/userTenantCollection.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Collection of user tenants",
+  "description": "Collection of primary tenant records",
   "properties": {
     "userTenants": {
-      "description": "List of user tenants",
+      "description": "List of primary tenant records",
       "type": "array",
       "id": "userTenants",
       "items": {

--- a/ramls/userTenants.raml
+++ b/ramls/userTenants.raml
@@ -1,0 +1,60 @@
+#%RAML 1.0
+title: User tenants
+baseUri: http://github.com/org/folio/mod-users
+
+documentation:
+  - title: mod-users User tenants API
+    content: This documents the API calls that can be made to query primary users affiliation
+
+types:
+  userTenant: !include userTenant.json
+  userTenantCollection: !include userTenantCollection.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  pageable: !include raml-util/traits/pageable.raml
+  validate: !include raml-util/traits/validation.raml
+  language: !include raml-util/traits/language.raml
+
+resourceTypes:
+  collection-get: !include raml-util/rtypes/collection-get.raml
+  collection-item-get: !include raml-util/rtypes/item-collection-get.raml
+
+/user-tenants:
+  type:
+    collection-get:
+      exampleCollection: !include examples/userTenantCollection.sample
+      exampleItem: !include examples/userTenant.sample
+      schemaCollection: userTenantCollection
+      schemaItem: userTenant
+  get:
+    is: [
+      pageable
+    ]
+    description: Return a list of user tenants
+    queryParameters:
+      userId:
+        description: Filter by user id
+        type: string
+        example: 11484f66-5121-43ea-81e7-6d9e3711495f
+        required: false
+      username:
+        description: Filter by user name
+        type: string
+        example: folio_user
+        required: false
+      tenantId:
+        description: Filter by tenant id
+        type: string
+        example: sfs000
+        required: false
+    responses:
+      200:
+        body:
+          application/json:
+            type: userTenantCollection
+      500:
+        description: "Internal server error"
+        body:
+          text/plain:
+            example: "Internal server error"

--- a/ramls/userTenants.raml
+++ b/ramls/userTenants.raml
@@ -4,7 +4,7 @@ baseUri: http://github.com/org/folio/mod-users
 
 documentation:
   - title: mod-users User tenants API
-    content: This documents the API calls that can be made to query primary users affiliation
+    content: Records that show the primary tenant for a user when doing single-sign-on
 
 types:
   userTenant: !include userTenant.json

--- a/src/main/java/org/folio/event/ConsortiumEventType.java
+++ b/src/main/java/org/folio/event/ConsortiumEventType.java
@@ -1,0 +1,14 @@
+package org.folio.event;
+
+public enum ConsortiumEventType {
+  CONSORTIUM_PRIMARY_AFFILIATION_CREATED("CONSORTIUM_PRIMARY_AFFILIATION_CREATED");
+  private final String topicName;
+
+  ConsortiumEventType(String topicName) {
+    this.topicName = topicName;
+  }
+
+  public String getTopicName() {
+    return topicName;
+  }
+}

--- a/src/main/java/org/folio/event/KafkaConfigSingleton.java
+++ b/src/main/java/org/folio/event/KafkaConfigSingleton.java
@@ -31,7 +31,7 @@ public enum KafkaConfigSingleton {
     return kafkaConfig;
   }
 
-  private static String getPropertyValue(String propertyName, String defaultValue) {
+  public static String getPropertyValue(String propertyName, String defaultValue) {
     return Optional.ofNullable(System.getProperty(propertyName))
       .or(() -> Optional.ofNullable(System.getenv(propertyName)))
       .orElse(defaultValue);

--- a/src/main/java/org/folio/event/service/UserTenantService.java
+++ b/src/main/java/org/folio/event/service/UserTenantService.java
@@ -1,0 +1,32 @@
+package org.folio.event.service;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import org.folio.repository.UserTenantRepository;
+import org.folio.rest.jaxrs.model.UserTenant;
+import org.folio.rest.jaxrs.model.UserTenantCollection;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
+
+import java.util.function.BiFunction;
+
+public class UserTenantService {
+
+  private final UserTenantRepository tenantRepository;
+  private final BiFunction<Vertx, String, PostgresClient> pgClientFactory;
+
+  public UserTenantService() {
+    pgClientFactory = PostgresClient::getInstance;
+    tenantRepository = new UserTenantRepository();
+  }
+
+  public Future<UserTenantCollection> fetchUserTenants(String tenantId, Criterion criterion, Vertx vertx) {
+    PostgresClient pgClient = pgClientFactory.apply(vertx, tenantId);
+    return pgClient.withConn(conn -> tenantRepository.fetchUserTenants(conn, tenantId, criterion));
+  }
+
+  public Future<Boolean> saveUserTenant(UserTenant userTenant, String tenantId, Vertx vertx) {
+    PostgresClient pgClient = pgClientFactory.apply(vertx, tenantId);
+    return pgClient.withConn(conn -> tenantRepository.saveUserTenant(conn, userTenant, tenantId));
+  }
+}

--- a/src/main/java/org/folio/event/util/PomReaderUtil.java
+++ b/src/main/java/org/folio/event/util/PomReaderUtil.java
@@ -1,0 +1,10 @@
+package org.folio.event.util;
+
+public enum PomReaderUtil {
+  INSTANCE;
+
+  public String constructModuleVersionAndVersion(String moduleName, String moduleVersion) {
+    String result = moduleName.replace("_", "-");
+    return result + "-" + moduleVersion;
+  }
+}

--- a/src/main/java/org/folio/repository/UserTenantRepository.java
+++ b/src/main/java/org/folio/repository/UserTenantRepository.java
@@ -1,0 +1,78 @@
+package org.folio.repository;
+
+import io.vertx.core.Future;
+import io.vertx.pgclient.PgException;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.kafka.exception.DuplicateEventException;
+import org.folio.rest.jaxrs.model.UserTenant;
+import org.folio.rest.jaxrs.model.UserTenantCollection;
+import org.folio.rest.persist.Conn;
+import org.folio.rest.persist.Criteria.Criterion;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
+
+public class UserTenantRepository {
+
+  public static final String USER_ID_FIELD = "user_id";
+  public static final String USERNAME_FIELD = "username";
+  public static final String TENANT_ID_FIELD = "tenant_id";
+  public static final String UNIQUE_CONSTRAINT_VIOLATION_CODE = "23505";
+
+  private static final String USER_TENANT_TABLE_NAME = "user_tenant";
+  private static final String ID_FIELD = "id";
+  private static final String TOTAL_COUNT_FIELD = "total_count";
+  private static final String INSERT_SQL = "INSERT INTO %s.%s (id, user_id, username, tenant_id, creation_date) VALUES ($1, $2, $3, $4, $5)";
+  private static final String SELECT_USER_TENANTS = "WITH cte AS (SELECT count(*) AS total_count FROM %1$s.%2$s %3$s) " +
+    "SELECT j.*, cte.* FROM %1$s.%2$s j LEFT JOIN cte ON true " +
+    "%3$s LIMIT %4$d OFFSET %5$d";
+
+  public Future<UserTenantCollection> fetchUserTenants(Conn conn, String tenantId, Criterion criterion) {
+    int limit = criterion.getLimit().get();
+    int offset = criterion.getOffset().get();
+    String whereClause = Optional.ofNullable(criterion.getWhere())
+      .filter(StringUtils::isNotBlank)
+      .map(clause -> "WHERE " + clause)
+      .orElse("");
+    String query = String.format(SELECT_USER_TENANTS, convertToPsqlStandard(tenantId), USER_TENANT_TABLE_NAME,
+      whereClause, limit, offset);
+    return conn.execute(query).map(this::mapResultSetToUserTenantCollection);
+  }
+
+  public Future<Boolean> saveUserTenant(Conn conn, UserTenant userTenant, String tenantId) {
+    String query = String.format(INSERT_SQL, convertToPsqlStandard(tenantId), USER_TENANT_TABLE_NAME);
+    Tuple queryParams = Tuple.of(userTenant.getId(), userTenant.getUserId(), userTenant.getUserName(),
+      userTenant.getTenantId(), OffsetDateTime.now(Clock.systemUTC()));
+    return conn.execute(query, queryParams).map(resultSet -> resultSet.size() == 1)
+      .recover(throwable -> handleFailures(throwable, userTenant.getId()));
+  }
+
+  private UserTenantCollection mapResultSetToUserTenantCollection(RowSet<Row> resultSet) {
+    UserTenantCollection userTenantCollection = new UserTenantCollection().withTotalRecords(0);
+    resultSet.iterator().forEachRemaining(row -> {
+      userTenantCollection.getUserTenants().add(mapRowToUserTenant(row));
+      userTenantCollection.setTotalRecords(row.getInteger(TOTAL_COUNT_FIELD));
+    });
+    return userTenantCollection;
+  }
+
+  private <T> Future<T> handleFailures(Throwable throwable, String id) {
+    return (throwable instanceof PgException && ((PgException) throwable).getCode().equals(UNIQUE_CONSTRAINT_VIOLATION_CODE)) ?
+      Future.failedFuture(new DuplicateEventException(String.format("Event with Id=%s is already processed.", id))) :
+      Future.failedFuture(throwable);
+  }
+
+  private UserTenant mapRowToUserTenant(Row row) {
+    return new UserTenant()
+      .withId(row.getValue(ID_FIELD).toString())
+      .withUserId(row.getValue(USER_ID_FIELD).toString())
+      .withUserName(row.getString(USERNAME_FIELD))
+      .withTenantId(row.getString(TENANT_ID_FIELD));
+  }
+}

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -1,0 +1,49 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.GenericCompositeFuture;
+import org.folio.rest.resource.interfaces.InitAPI;
+import org.folio.verticle.ConsortiumEventConsumersVerticle;
+
+import java.util.Collections;
+
+import static org.folio.event.KafkaConfigSingleton.getPropertyValue;
+
+public class InitAPIs implements InitAPI {
+  private final Logger logger = LogManager.getLogger(InitAPIs.class);
+
+  @Override
+  public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> handler) {
+    logger.info("InitAPI starting...");
+    try {
+      deployConsumersVerticles(vertx)
+        .onSuccess(car -> {
+          handler.handle(Future.succeededFuture());
+          logger.info("Consumer Verticles were successfully started");
+        })
+        .onFailure(th -> {
+          handler.handle(Future.failedFuture(th));
+          logger.error("Consumer Verticles were not started", th);
+        });
+    } catch (Throwable th) {
+      logger.error("Error during module init", th);
+      handler.handle(Future.failedFuture(th));
+    }
+  }
+
+  private Future<?> deployConsumersVerticles(Vertx vertx) {
+    Promise<String> consortiaEventsConsumer = Promise.promise();
+    int usersConsortiumConsumerInstancesNumber = Integer.parseInt(getPropertyValue("users.consortium.kafka.consumer.instancesNumber", "1"));
+
+    vertx.deployVerticle((ConsortiumEventConsumersVerticle.class.getName()),
+      new DeploymentOptions()
+        .setWorker(true)
+        .setInstances(usersConsortiumConsumerInstancesNumber), consortiaEventsConsumer);
+
+    return GenericCompositeFuture.all(Collections.singletonList(
+      consortiaEventsConsumer.future()));
+  }
+
+}

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -1,0 +1,58 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.event.service.UserTenantService;
+import org.folio.rest.jaxrs.resource.UserTenants;
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.Criteria.Limit;
+import org.folio.rest.persist.Criteria.Offset;
+import org.folio.rest.tools.utils.TenantTool;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.repository.UserTenantRepository.USER_ID_FIELD;
+import static org.folio.repository.UserTenantRepository.USERNAME_FIELD;
+import static org.folio.repository.UserTenantRepository.TENANT_ID_FIELD;
+
+public class UserTenantsAPI implements UserTenants {
+
+  private final UserTenantService userTenantService;
+
+  public UserTenantsAPI() {
+    this.userTenantService = new UserTenantService();
+  }
+
+  @Override
+  public void getUserTenants(String userId, String username, String tenantId, int offset, int limit, String lang,
+                             Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                             Context vertxContext) {
+    String okapiTenantId = TenantTool.tenantId(okapiHeaders);
+    Criterion criterion = new Criterion().setLimit(new Limit(limit)).setOffset(new Offset(offset));
+    addWhereClauseArgumentsToCriterion(userId, username, tenantId, criterion);
+
+    userTenantService.fetchUserTenants(okapiTenantId, criterion, vertxContext.owner())
+      .onSuccess(res -> asyncResultHandler.handle(
+        succeededFuture(GetUserTenantsResponse.respond200WithApplicationJson(res))))
+      .onFailure(cause -> asyncResultHandler.handle(
+        succeededFuture(GetUserTenantsResponse.respond500WithTextPlain(cause.getMessage()))));
+  }
+
+  private void addWhereClauseArgumentsToCriterion(String userId, String username, String tenantId, Criterion criterion) {
+    Map<String, String> fields = Map.of(
+      USER_ID_FIELD, StringUtils.defaultString(userId),
+      USERNAME_FIELD, StringUtils.defaultString(username),
+      TENANT_ID_FIELD, StringUtils.defaultString(tenantId)
+    );
+
+    fields.entrySet().stream()
+      .filter(entry -> StringUtils.isNotBlank(entry.getValue()))
+      .map(entry -> new Criteria().addField(entry.getKey()).setOperation("=").setVal(entry.getValue()).setJSONB(false))
+      .forEach(criterion::addCriterion);
+  }
+}

--- a/src/main/java/org/folio/rest/utils/OkapiConnectionParams.java
+++ b/src/main/java/org/folio/rest/utils/OkapiConnectionParams.java
@@ -1,0 +1,73 @@
+package org.folio.rest.utils;
+
+import io.vertx.core.Vertx;
+
+import java.util.Map;
+
+public class OkapiConnectionParams {
+  public static final String OKAPI_URL_HEADER = "x-okapi-url";
+  public static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
+  public static final String OKAPI_TOKEN_HEADER = "x-okapi-token";
+  private String okapiUrl;
+  private String tenantId;
+  private String token;
+  private Map<String, String> headers;
+  private final Vertx vertx;
+  private int timeout = 2000;
+
+  public OkapiConnectionParams(Map<String, String> okapiHeaders, Vertx vertx) {
+    this.okapiUrl = okapiHeaders.getOrDefault(OKAPI_URL_HEADER, "localhost");
+    this.tenantId = okapiHeaders.getOrDefault(OKAPI_TENANT_HEADER, "");
+    this.token = okapiHeaders.getOrDefault(OKAPI_TOKEN_HEADER, "dummy");
+    this.headers = okapiHeaders;
+    this.vertx = vertx;
+  }
+
+  public OkapiConnectionParams(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  public String getOkapiUrl() {
+    return this.okapiUrl;
+  }
+
+  public String getTenantId() {
+    return this.tenantId;
+  }
+
+  public String getToken() {
+    return this.token;
+  }
+
+  public Map<String, String> getHeaders() {
+    return this.headers;
+  }
+
+  public Vertx getVertx() {
+    return this.vertx;
+  }
+
+  public int getTimeout() {
+    return this.timeout;
+  }
+
+  public void setOkapiUrl(String okapiUrl) {
+    this.okapiUrl = okapiUrl;
+  }
+
+  public void setTenantId(String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+
+  public void setHeaders(Map<String, String> headers) {
+    this.headers = headers;
+  }
+
+  public void setTimeout(int timeout) {
+    this.timeout = timeout;
+  }
+}

--- a/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
+++ b/src/main/java/org/folio/verticle/AbstractConsumersVerticle.java
@@ -1,0 +1,70 @@
+package org.folio.verticle;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.folio.event.KafkaConfigSingleton;
+import org.folio.event.util.PomReaderUtil;
+import org.folio.kafka.GlobalLoadSensor;
+import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.SubscriptionDefinition;
+import org.folio.kafka.KafkaTopicNameHelper;
+import org.folio.kafka.KafkaConsumerWrapper;
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.okapi.common.GenericCompositeFuture;
+import org.folio.rest.tools.utils.ModuleName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.folio.event.KafkaConfigSingleton.getPropertyValue;
+
+public abstract class AbstractConsumersVerticle extends AbstractVerticle {
+
+  private static final GlobalLoadSensor globalLoadSensor = new GlobalLoadSensor();
+
+  @Override
+  public void start(Promise<Void> startPromise) {
+    List<Future<Void>> futures = new ArrayList<>();
+    KafkaConfig kafkaConfig = KafkaConfigSingleton.INSTANCE.getKafkaConfig();
+    int loadLimit = Integer.parseInt(getPropertyValue("users.kafka.UsersConsumer.loadLimit", "5"));
+    getEvents().forEach(event -> {
+      SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper
+        .createSubscriptionDefinition(kafkaConfig.getEnvId(),
+          KafkaTopicNameHelper.getDefaultNameSpace(),
+          event);
+      KafkaConsumerWrapper<String, String> consumerWrapper = KafkaConsumerWrapper.<String, String>builder()
+        .context(context)
+        .vertx(vertx)
+        .kafkaConfig(kafkaConfig)
+        .loadLimit(loadLimit)
+        .globalLoadSensor(globalLoadSensor)
+        .subscriptionDefinition(subscriptionDefinition)
+        .build();
+
+      futures.add(consumerWrapper.start(getHandler(),
+        constructModuleName() + "_" + getClass().getSimpleName()));
+    });
+
+    GenericCompositeFuture.all(futures).onComplete(ar -> startPromise.complete());
+  }
+
+  private String constructModuleName() {
+    return PomReaderUtil.INSTANCE.constructModuleVersionAndVersion(ModuleName.getModuleName(),
+      ModuleName.getModuleVersion());
+  }
+
+  /**
+   * Events that consumer subscribed to.
+   *
+   * @return list of events
+   */
+  public abstract List<String> getEvents();
+
+  /**
+   * Handler that will be invoked when kafka messages comes to processing.
+   *
+   * @return handler to porcess kafka message
+   */
+  public abstract AsyncRecordHandler<String, String> getHandler();
+}

--- a/src/main/java/org/folio/verticle/ConsortiumEventConsumersVerticle.java
+++ b/src/main/java/org/folio/verticle/ConsortiumEventConsumersVerticle.java
@@ -1,0 +1,19 @@
+package org.folio.verticle;
+
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.verticle.consumers.ConsortiumEventsHandler;
+
+import java.util.List;
+
+import static org.folio.event.ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED;
+
+public class ConsortiumEventConsumersVerticle extends AbstractConsumersVerticle {
+
+  public List<String> getEvents() {
+    return List.of(CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName());
+  }
+
+  public AsyncRecordHandler<String, String> getHandler() {
+    return new ConsortiumEventsHandler(vertx);
+  }
+}

--- a/src/main/java/org/folio/verticle/consumers/ConsortiumEventsHandler.java
+++ b/src/main/java/org/folio/verticle/consumers/ConsortiumEventsHandler.java
@@ -1,0 +1,61 @@
+package org.folio.verticle.consumers;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.event.service.UserTenantService;
+import org.folio.kafka.AsyncRecordHandler;
+import org.folio.kafka.KafkaHeaderUtils;
+import org.folio.kafka.exception.DuplicateEventException;
+import org.folio.rest.jaxrs.model.UserTenant;
+import org.folio.rest.utils.OkapiConnectionParams;
+
+import java.util.List;
+
+public class ConsortiumEventsHandler implements AsyncRecordHandler<String, String> {
+
+  private static final Logger logger = LogManager.getLogger(ConsortiumEventsHandler.class);
+
+  private final Vertx vertx;
+  private final UserTenantService userTenantService;
+
+  public ConsortiumEventsHandler(Vertx vertx) {
+    this.vertx = vertx;
+    this.userTenantService = new UserTenantService();
+  }
+
+  @Override
+  public Future<String> handle(KafkaConsumerRecord<String, String> record) {
+    Promise<String> result = Promise.promise();
+    List<KafkaHeader> kafkaHeaders = record.headers();
+    OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
+    UserTenant event = new JsonObject(record.value()).mapTo(UserTenant.class);
+    logger.info("Trying to save of user primary affiliation event with consortium id: {} for user id: {} with tenant id: {}",
+      event.getId(), event.getUserId(), event.getTenantId());
+
+    userTenantService.saveUserTenant(event, okapiConnectionParams.getTenantId(), okapiConnectionParams.getVertx())
+      .onSuccess(ar -> {
+        logger.info("User primary affiliation event with consortium id: {} has been saved for user id: {} with tenant id: {}",
+          event.getId(), event.getUserId(), event.getTenantId());
+        result.complete(event.getId());
+      })
+      .onFailure(e -> {
+        if (e instanceof DuplicateEventException) {
+          logger.info("Duplicate user primary affiliation event with consortium id: {} for user id: {} with tenant id: {} received, skipped processing",
+            event.getId(), event.getUserId(), event.getTenantId());
+          result.complete(event.getId());
+        } else {
+          logger.error("Trying to save of user primary affiliation event with consortium id: {} for user id: {} with tenant id: {} has been failed",
+            event.getId(), event.getUserId(), event.getTenantId(), e);
+          result.fail(e);
+        }
+      });
+
+    return result.future();
+  }
+}

--- a/src/main/resources/templates/db_scripts/create_user_tenants_table.sql
+++ b/src/main/resources/templates/db_scripts/create_user_tenants_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS user_tenant (
+  id uuid PRIMARY KEY,
+  user_id uuid NOT NULL,
+  username text NOT NULL,
+  tenant_id text NOT NULL,
+  creation_date timestamp without time zone
+);
+
+CREATE INDEX IF NOT EXISTS username_idx ON user_tenant USING BTREE (username);

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -36,6 +36,11 @@
       "fromModuleVersion": "19.2.0"
     },
     {
+      "run": "after",
+      "snippetPath": "create_user_tenants_table.sql",
+      "fromModuleVersion": "19.2.0"
+    },
+    {
       "run": "before",
       "snippet": "DO $$ BEGIN DROP TABLE patron_block_conditions, patron_block_limits; EXCEPTION WHEN OTHERS THEN END; $$;",
       "fromModuleVersion": "mod-users-16.2.1"

--- a/src/test/java/org/folio/moduserstest/AbstractRestTest.java
+++ b/src/test/java/org/folio/moduserstest/AbstractRestTest.java
@@ -44,9 +44,6 @@ public abstract class AbstractRestTest {
   public static final String KAFKA_ENV_VALUE = "test-env";
   public static final List<String> KAFKA_CONTAINER_PORTS = List.of("11541:2181", "11542:9092", "11543:9093");
 
-  protected static boolean LOAD_SAMPLE_DATA = false;
-  protected static boolean LOAD_REFERENCE_DATA = false;
-
   protected static VertxModule module;
   protected static OkapiUrl okapiUrl;
   protected static OkapiHeaders okapiHeaders;
@@ -57,7 +54,7 @@ public abstract class AbstractRestTest {
 
   @BeforeAll
   @SneakyThrows
-  public static void beforeAll(Vertx vertx, VertxTestContext context) {
+  public static void beforeAll(Vertx vertx, VertxTestContext context, boolean hasData) {
     final var token = new FakeTokenGenerator().generateToken();
 
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
@@ -91,7 +88,7 @@ public abstract class AbstractRestTest {
     module = new VertxModule(vertx);
 
     module.deployModule(port)
-      .compose(res -> module.enableModule(okapiHeaders, LOAD_REFERENCE_DATA, LOAD_SAMPLE_DATA))
+      .compose(res -> module.enableModule(okapiHeaders, hasData, hasData))
       .onComplete(context.succeedingThenComplete());
   }
 

--- a/src/test/java/org/folio/moduserstest/AbstractRestTest.java
+++ b/src/test/java/org/folio/moduserstest/AbstractRestTest.java
@@ -22,7 +22,6 @@ import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.support.VertxModule;
 import org.folio.support.http.*;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -52,7 +51,6 @@ public abstract class AbstractRestTest {
   private static final KafkaContainer kafkaContainer =
     new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.3.1"));
 
-  @BeforeAll
   @SneakyThrows
   public static void beforeAll(Vertx vertx, VertxTestContext context, boolean hasData) {
     final var token = new FakeTokenGenerator().generateToken();

--- a/src/test/java/org/folio/moduserstest/AbstractRestTest.java
+++ b/src/test/java/org/folio/moduserstest/AbstractRestTest.java
@@ -105,8 +105,7 @@ public abstract class AbstractRestTest {
         PostgresClient.stopPostgresTester();
         return Future.succeededFuture();
       })
-      .onComplete(future -> context.completeNow())
-      .onFailure(context::failNow);
+      .onComplete(context.succeedingThenComplete());
   }
 
   public List<String> checkKafkaEventSent(String tenant, String eventType) {

--- a/src/test/java/org/folio/moduserstest/AbstractRestTestNoData.java
+++ b/src/test/java/org/folio/moduserstest/AbstractRestTestNoData.java
@@ -1,0 +1,13 @@
+package org.folio.moduserstest;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.BeforeAll;
+
+public class AbstractRestTestNoData extends AbstractRestTest {
+
+  @BeforeAll
+  public static void beforeAll(Vertx vertx, VertxTestContext context) {
+    AbstractRestTest.beforeAll(vertx, context, false);
+  }
+}

--- a/src/test/java/org/folio/moduserstest/AbstractRestTestWithData.java
+++ b/src/test/java/org/folio/moduserstest/AbstractRestTestWithData.java
@@ -1,0 +1,13 @@
+package org.folio.moduserstest;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.BeforeAll;
+
+public class AbstractRestTestWithData extends AbstractRestTest {
+
+  @BeforeAll
+  public static void beforeAll(Vertx vertx, VertxTestContext context) {
+    AbstractRestTest.beforeAll(vertx, context, true);
+  }
+}

--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -24,7 +24,7 @@ import io.vertx.junit5.VertxExtension;
 
 @Timeout(value = 20, timeUnit = SECONDS)
 @ExtendWith(VertxExtension.class)
-public class CustomFieldIT extends AbstractRestTest {
+public class CustomFieldIT extends AbstractRestTestNoData {
 
   private static UsersClient usersClient;
   private static CustomFieldsClient customFieldsClient;

--- a/src/test/java/org/folio/moduserstest/ExpirationIT.java
+++ b/src/test/java/org/folio/moduserstest/ExpirationIT.java
@@ -24,15 +24,13 @@ import io.vertx.junit5.VertxExtension;
 
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 20, unit = SECONDS)
-class ExpirationIT extends AbstractRestTest {
+class ExpirationIT extends AbstractRestTestNoData {
 
   private static UsersClient usersClient;
   private static TimerInterfaceClient timerInterfaceClient;
 
   @BeforeAll
   public static void beforeAll() {
-    LOAD_SAMPLE_DATA = false;
-    LOAD_REFERENCE_DATA = false;
     usersClient = new UsersClient(okapiUrl, okapiHeaders);
     timerInterfaceClient = new TimerInterfaceClient(okapiUrl, okapiHeaders);
   }

--- a/src/test/java/org/folio/moduserstest/GroupIT.java
+++ b/src/test/java/org/folio/moduserstest/GroupIT.java
@@ -27,7 +27,7 @@ import io.vertx.junit5.VertxExtension;
 
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 20, unit = SECONDS)
-class GroupIT extends AbstractRestTest{
+class GroupIT extends AbstractRestTestNoData {
 
   private static GroupsClient groupsClient;
   private static UsersClient usersClient;

--- a/src/test/java/org/folio/moduserstest/ProxyRelationshipsIT.java
+++ b/src/test/java/org/folio/moduserstest/ProxyRelationshipsIT.java
@@ -31,7 +31,7 @@ import io.vertx.junit5.VertxExtension;
  */
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 20, unit = SECONDS)
-class ProxyRelationshipsIT extends AbstractRestTest {
+class ProxyRelationshipsIT extends AbstractRestTestNoData {
 
   private static ProxiesClient proxiesClient;
 

--- a/src/test/java/org/folio/moduserstest/UserOutboxProcessIT.java
+++ b/src/test/java/org/folio/moduserstest/UserOutboxProcessIT.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(VertxExtension.class)
 @Timeout(value = 10, unit = SECONDS)
-public class UserOutboxProcessIT extends AbstractRestTest {
+public class UserOutboxProcessIT extends AbstractRestTestNoData {
 
   private static final OutboxEventLog OUTBOX_EVENT_LOG = new OutboxEventLog()
     .withEventId(UUID.randomUUID().toString())
@@ -43,8 +43,6 @@ public class UserOutboxProcessIT extends AbstractRestTest {
 
   @BeforeAll
   public static void beforeAll() {
-    LOAD_SAMPLE_DATA = false;
-    LOAD_REFERENCE_DATA = false;
     userEventsLogRepository = new UserEventsLogRepository();
     timerInterfaceClient = new TimerInterfaceClient(okapiUrl, okapiHeaders);
   }

--- a/src/test/java/org/folio/rest/InstallUpgradeIT.java
+++ b/src/test/java/org/folio/rest/InstallUpgradeIT.java
@@ -1,0 +1,78 @@
+package org.folio.rest;
+
+import io.restassured.RestAssured;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.file.Path;
+
+/**
+ * Check the shaded fat uber jar and Dockerfile.
+ *
+ * <p>Test /admin/health.
+ *
+ * <p>Test that logging works.
+ *
+ * <p>Test installation and migration with smoke test.
+ *
+ */
+public class InstallUpgradeIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InstallUpgradeIT.class);
+  private static final boolean IS_LOG_ENABLED = false;
+  private static final Network NETWORK = Network.newNetwork();
+
+  @ClassRule(order = 1)
+  public static final KafkaContainer KAFKA =
+    new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.0.3"))
+      .withNetwork(NETWORK)
+      .withNetworkAliases("mykafka");
+
+  @ClassRule(order = 2)
+  public static final GenericContainer<?> MOD_USERS =
+    new GenericContainer<>(
+      new ImageFromDockerfile("mod-users").withFileFromPath(".", Path.of(".")))
+      .withNetwork(NETWORK)
+      .withExposedPorts(8081)
+      .withEnv("KAFKA_HOST", "mykafka")
+      .withEnv("KAFKA_PORT", "9092");
+
+  @BeforeClass
+  public static void beforeClass() {
+    RestAssured.reset();
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    RestAssured.baseURI = "http://" + MOD_USERS.getHost() + ":" + MOD_USERS.getFirstMappedPort();
+    if (IS_LOG_ENABLED) {
+      KAFKA.followOutput(new Slf4jLogConsumer(LOG).withSeparateOutputStreams());
+      MOD_USERS.followOutput(new Slf4jLogConsumer(LOG).withSeparateOutputStreams());
+    }
+  }
+
+  @Before
+  public void beforeEach() {
+    RestAssured.requestSpecification = null;
+  }
+
+  @Test
+  public void health() {
+    // request without X-Okapi-Tenant
+    when().
+      get("/admin/health").
+      then().
+      statusCode(200).
+      body(is("\"OK\""));
+  }
+
+}

--- a/src/test/java/org/folio/rest/InstallUpgradeIT.java
+++ b/src/test/java/org/folio/rest/InstallUpgradeIT.java
@@ -18,16 +18,6 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.nio.file.Path;
 
-/**
- * Check the shaded fat uber jar and Dockerfile.
- *
- * <p>Test /admin/health.
- *
- * <p>Test that logging works.
- *
- * <p>Test installation and migration with smoke test.
- *
- */
 public class InstallUpgradeIT {
 
   private static final Logger LOG = LoggerFactory.getLogger(InstallUpgradeIT.class);

--- a/src/test/java/org/folio/rest/impl/AddressTypesIT.java
+++ b/src/test/java/org/folio/rest/impl/AddressTypesIT.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.hasSize;
 import java.util.List;
 import java.util.UUID;
 
-import org.folio.moduserstest.AbstractRestTest;
+import org.folio.moduserstest.AbstractRestTestNoData;
 import org.folio.support.Address;
 import org.folio.support.AddressType;
 import org.folio.support.Personal;
@@ -32,7 +32,7 @@ import io.vertx.junit5.VertxExtension;
 
 @Timeout(value = 20, timeUnit = SECONDS)
 @ExtendWith(VertxExtension.class)
-class AddressTypesIT extends AbstractRestTest {
+class AddressTypesIT extends AbstractRestTestNoData {
 
   private static UsersClient usersClient;
   private static GroupsClient groupsClient;

--- a/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import io.restassured.http.Header;
 import io.vertx.core.json.Json;
-import io.vertx.ext.unit.TestContext;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,13 +49,9 @@ public class CustomFieldTestBase extends TestBase {
     DockerImageName.parse("confluentinc/cp-kafka:7.3.1"));
 
   @BeforeClass
-  public static void setUpClass(TestContext context) {
+  public static void beforeClass() {
     kafkaContainer.setPortBindings(KAFKA_CONTAINER_PORTS);
     kafkaContainer.start();
-    System.setProperty(KAFKA_HOST, kafkaContainer.getHost());
-    System.setProperty(KAFKA_PORT, String.valueOf(kafkaContainer.getFirstMappedPort()));
-    System.setProperty(KAFKA_ENV, KAFKA_ENV_VALUE);
-    TestBase.setUpClass(context);
   }
 
   @Before
@@ -161,5 +156,11 @@ public class CustomFieldTestBase extends TestBase {
       Assert.fail(e.getMessage());
       return null;
     }
+  }
+
+  static {
+    System.setProperty(KAFKA_HOST, "localhost");
+    System.setProperty(KAFKA_PORT, "11543");
+    System.setProperty(KAFKA_ENV, KAFKA_ENV_VALUE);
   }
 }

--- a/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import io.restassured.http.Header;
 import io.vertx.core.json.Json;
+import io.vertx.ext.unit.TestContext;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -49,12 +50,13 @@ public class CustomFieldTestBase extends TestBase {
     DockerImageName.parse("confluentinc/cp-kafka:7.3.1"));
 
   @BeforeClass
-  public static void setUpClass() {
+  public static void setUpClass(TestContext context) {
     kafkaContainer.setPortBindings(KAFKA_CONTAINER_PORTS);
     kafkaContainer.start();
     System.setProperty(KAFKA_HOST, kafkaContainer.getHost());
     System.setProperty(KAFKA_PORT, String.valueOf(kafkaContainer.getFirstMappedPort()));
     System.setProperty(KAFKA_ENV, KAFKA_ENV_VALUE);
+    TestBase.setUpClass(context);
   }
 
   @Before

--- a/src/test/java/org/folio/rest/impl/DepartmentsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/DepartmentsAPITest.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import io.restassured.http.Header;
-import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -66,13 +65,9 @@ public class DepartmentsAPITest extends TestBase {
     DockerImageName.parse("confluentinc/cp-kafka:7.3.1"));
 
   @BeforeClass
-  public static void setUpClass(TestContext context) {
+  public static void beforeClass() {
     kafkaContainer.setPortBindings(KAFKA_CONTAINER_PORTS);
     kafkaContainer.start();
-    System.setProperty(KAFKA_HOST, kafkaContainer.getHost());
-    System.setProperty(KAFKA_PORT, String.valueOf(kafkaContainer.getFirstMappedPort()));
-    System.setProperty(KAFKA_ENV, KAFKA_ENV_VALUE);
-    TestBase.setUpClass(context);
   }
 
   @Before
@@ -424,4 +419,9 @@ public class DepartmentsAPITest extends TestBase {
     return user;
   }
 
+  static {
+    System.setProperty(KAFKA_HOST, "localhost");
+    System.setProperty(KAFKA_PORT, "11543");
+    System.setProperty(KAFKA_ENV, KAFKA_ENV_VALUE);
+  }
 }

--- a/src/test/java/org/folio/rest/impl/DepartmentsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/DepartmentsAPITest.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import io.restassured.http.Header;
+import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -65,12 +66,13 @@ public class DepartmentsAPITest extends TestBase {
     DockerImageName.parse("confluentinc/cp-kafka:7.3.1"));
 
   @BeforeClass
-  public static void setUpClass() {
+  public static void setUpClass(TestContext context) {
     kafkaContainer.setPortBindings(KAFKA_CONTAINER_PORTS);
     kafkaContainer.start();
     System.setProperty(KAFKA_HOST, kafkaContainer.getHost());
     System.setProperty(KAFKA_PORT, String.valueOf(kafkaContainer.getFirstMappedPort()));
     System.setProperty(KAFKA_ENV, KAFKA_ENV_VALUE);
+    TestBase.setUpClass(context);
   }
 
   @Before

--- a/src/test/java/org/folio/rest/impl/DepartmentsAPITest.java
+++ b/src/test/java/org/folio/rest/impl/DepartmentsAPITest.java
@@ -6,6 +6,7 @@ import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.folio.moduserstest.AbstractRestTest.*;
 import static org.folio.moduserstest.AbstractRestTest.KAFKA_ENV_VALUE;
+import static org.folio.rest.impl.CustomFieldTestBase.updateKafkaConfigField;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -71,9 +72,9 @@ public class DepartmentsAPITest extends TestBase {
     protected void before() {
       kafkaContainer.setPortBindings(KAFKA_CONTAINER_PORTS);
       kafkaContainer.start();
-      System.setProperty(KAFKA_HOST, kafkaContainer.getHost());
-      System.setProperty(KAFKA_PORT, String.valueOf(kafkaContainer.getFirstMappedPort()));
-      System.setProperty(KAFKA_ENV, KAFKA_ENV_VALUE);
+      updateKafkaConfigField("envId", KAFKA_ENV_VALUE);
+      updateKafkaConfigField("kafkaHost", kafkaContainer.getHost());
+      updateKafkaConfigField("kafkaPort", String.valueOf(kafkaContainer.getFirstMappedPort()));
     }
 
     @Override

--- a/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
@@ -4,7 +4,7 @@ package org.folio.rest.impl;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 
-import org.folio.moduserstest.AbstractRestTest;
+import org.folio.moduserstest.AbstractRestTestNoData;
 import org.folio.support.User;
 import org.folio.support.http.PatronPinClient;
 import org.folio.support.http.UsersClient;
@@ -24,7 +24,7 @@ import io.vertx.junit5.VertxTestContext;
 
 @Timeout(value = 20, timeUnit = SECONDS)
 @ExtendWith(VertxExtension.class)
-class PatronPinAPIIT extends AbstractRestTest {
+class PatronPinAPIIT extends AbstractRestTestNoData {
 
   private static UsersClient usersClient;
   private static PatronPinClient patronPinClient;

--- a/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
+++ b/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataIT.java
@@ -6,7 +6,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-import org.folio.moduserstest.AbstractRestTest;
+import org.folio.moduserstest.AbstractRestTestWithData;
 import org.folio.support.http.AddressTypesClient;
 import org.folio.support.http.GroupsClient;
 import org.folio.support.http.UsersClient;
@@ -20,7 +20,7 @@ import io.vertx.junit5.VertxExtension;
 // Loading the reference and sample data can take a long time
 @Timeout(value = 30, timeUnit = SECONDS)
 @ExtendWith(VertxExtension.class)
-class ReferenceAndSampleDataIT extends AbstractRestTest {
+class ReferenceAndSampleDataIT extends AbstractRestTestWithData {
 
   private static UsersClient usersClient;
   private static GroupsClient groupsClient;
@@ -28,8 +28,6 @@ class ReferenceAndSampleDataIT extends AbstractRestTest {
 
   @BeforeAll
   static void beforeAll() {
-    LOAD_SAMPLE_DATA = true;
-    LOAD_REFERENCE_DATA = true;
     usersClient = new UsersClient(okapiUrl, okapiHeaders);
     groupsClient = new GroupsClient(okapiUrl, okapiHeaders);
     addressTypesClient = new AddressTypesClient(okapiUrl, okapiHeaders);

--- a/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataMigrationIT.java
+++ b/src/test/java/org/folio/rest/impl/ReferenceAndSampleDataMigrationIT.java
@@ -5,7 +5,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.folio.moduserstest.AbstractRestTest;
+import org.folio.moduserstest.AbstractRestTestWithData;
 import org.folio.support.http.AddressTypesClient;
 import org.folio.support.http.GroupsClient;
 import org.folio.support.http.UsersClient;
@@ -20,7 +20,7 @@ import lombok.SneakyThrows;
 
 @Timeout(value = 30, timeUnit = SECONDS)
 @ExtendWith(VertxExtension.class)
-class ReferenceAndSampleDataMigrationIT extends AbstractRestTest {
+class ReferenceAndSampleDataMigrationIT extends AbstractRestTestWithData {
 
   private static UsersClient usersClient;
   private static GroupsClient groupsClient;
@@ -29,8 +29,6 @@ class ReferenceAndSampleDataMigrationIT extends AbstractRestTest {
   @BeforeAll
   @SneakyThrows
   static void beforeAll() {
-    LOAD_SAMPLE_DATA = true;
-    LOAD_REFERENCE_DATA = true;
     usersClient = new UsersClient(okapiUrl, okapiHeaders);
     groupsClient = new GroupsClient(okapiUrl, okapiHeaders);
     addressTypesClient = new AddressTypesClient(okapiUrl, okapiHeaders);

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -5,7 +5,7 @@ import io.vertx.junit5.VertxExtension;
 import lombok.SneakyThrows;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.event.ConsortiumEventType;
-import org.folio.moduserstest.AbstractRestTest;
+import org.folio.moduserstest.AbstractRestTestNoData;
 import org.folio.rest.jaxrs.model.UserTenant;
 import org.folio.rest.jaxrs.model.UserTenantCollection;
 import org.folio.support.http.UserTenantClient;
@@ -21,7 +21,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @ExtendWith(VertxExtension.class)
-class UserTenantIT extends AbstractRestTest {
+class UserTenantIT extends AbstractRestTestNoData {
 
   private static UserTenantClient userTenantClient;
   private static final UserTenant USER_AFFILIATION =  new UserTenant()
@@ -34,12 +34,6 @@ class UserTenantIT extends AbstractRestTest {
   @SneakyThrows
   static void beforeAll() {
     userTenantClient = new UserTenantClient(okapiUrl, okapiHeaders);
-  }
-
-  @BeforeEach
-  public void beforeEach() {
-    LOAD_SAMPLE_DATA = false;
-    LOAD_REFERENCE_DATA = false;
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @ExtendWith(VertxExtension.class)
-class UserTenantITTest extends AbstractRestTest {
+class UserTenantIT extends AbstractRestTest {
 
   private static UserTenantClient userTenantClient;
   private static final UserTenant USER_AFFILIATION =  new UserTenant()
@@ -44,12 +44,8 @@ class UserTenantITTest extends AbstractRestTest {
 
   @Test
   void canCreateUserTenant() {
-    //given
-    String eventPayload = Json.encode(USER_AFFILIATION);
     //when
-    sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName(),
-      USER_AFFILIATION.getId(), eventPayload);
-    awaitHandlingEvent();
+    sendAffiliationCreatedEvent();
     //then
     UserTenantCollection collection = userTenantClient.getAllUsersTenants();
     Assertions.assertEquals(1, collection.getTotalRecords());
@@ -66,17 +62,28 @@ class UserTenantITTest extends AbstractRestTest {
   void canSearchByUserName() {
     //given
     String username = USER_AFFILIATION.getUserName();
-    String eventPayload = Json.encode(USER_AFFILIATION);
     Map<String, String> params = Map.of("username", username);
     //when
-    sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName(),
-      USER_AFFILIATION.getId(), eventPayload);
-    awaitHandlingEvent();
+    sendAffiliationCreatedEvent();
     //then
     UserTenantCollection collection = userTenantClient.getUserTenants(params);
     UserTenant userTenant = collection.getUserTenants().iterator().next();
     Assertions.assertEquals(1, collection.getTotalRecords());
     Assertions.assertEquals(username, userTenant.getUserName());
+  }
+
+  @Test
+  void canSearchByUserId() {
+    //given
+    String userId = USER_AFFILIATION.getUserId();
+    Map<String, String> params = Map.of("userId", userId);
+    //when
+    sendAffiliationCreatedEvent();
+    //then
+    UserTenantCollection collection = userTenantClient.getUserTenants(params);
+    UserTenant userTenant = collection.getUserTenants().iterator().next();
+    Assertions.assertEquals(1, collection.getTotalRecords());
+    Assertions.assertEquals(userId, userTenant.getUserId());
   }
 
   @Test
@@ -87,11 +94,8 @@ class UserTenantITTest extends AbstractRestTest {
     Map<String, String> params = Map.of(
       "username", username,
       "tenantId", tenantId);
-    String eventPayload = Json.encode(USER_AFFILIATION);
     //when
-    sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName(),
-      USER_AFFILIATION.getId(), eventPayload);
-    awaitHandlingEvent();
+    sendAffiliationCreatedEvent();
     //then
     UserTenantCollection collection = userTenantClient.getUserTenants(params);
     Assertions.assertEquals(1, collection.getTotalRecords());
@@ -108,5 +112,12 @@ class UserTenantITTest extends AbstractRestTest {
         UserTenantCollection collection = userTenantClient.getAllUsersTenants();
         return CollectionUtils.isNotEmpty(collection.getUserTenants());
       });
+  }
+
+  private void sendAffiliationCreatedEvent() {
+    String eventPayload = Json.encode(USER_AFFILIATION);
+    sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName(),
+      USER_AFFILIATION.getId(), eventPayload);
+    awaitHandlingEvent();
   }
 }

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -3,7 +3,6 @@ package org.folio.rest.impl;
 import io.vertx.core.json.Json;
 import io.vertx.junit5.VertxExtension;
 import lombok.SneakyThrows;
-import org.apache.commons.collections4.CollectionUtils;
 import org.folio.event.ConsortiumEventType;
 import org.folio.moduserstest.AbstractRestTestNoData;
 import org.folio.rest.jaxrs.model.UserTenant;
@@ -16,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -24,11 +24,23 @@ import java.util.concurrent.TimeUnit;
 class UserTenantIT extends AbstractRestTestNoData {
 
   private static UserTenantClient userTenantClient;
-  private static final UserTenant USER_AFFILIATION =  new UserTenant()
+
+  private static final String USER_A = "user_a";
+  private static final String USER_B = "user_b";
+  private static final String TENANT_X = "tenant_x";
+  private static final String TENANT_Y = "tenant_y";
+  private static final UserTenant FIRST_AFFILIATION = new UserTenant()
     .withId(UUID.randomUUID().toString())
     .withUserId(UUID.randomUUID().toString())
-    .withUserName("folio_user")
-    .withTenantId("folio_tenant");
+    .withUserName(USER_A).withTenantId(TENANT_X);
+  private static final UserTenant SECOND_AFFILIATION = new UserTenant()
+    .withId(UUID.randomUUID().toString())
+    .withUserId(UUID.randomUUID().toString())
+    .withUserName(USER_B).withTenantId(TENANT_X);
+  private static final UserTenant THIRD_AFFILIATION = new UserTenant()
+    .withId(UUID.randomUUID().toString())
+    .withUserId(UUID.randomUUID().toString())
+    .withUserName(USER_A).withTenantId(TENANT_Y);
 
   @BeforeAll
   @SneakyThrows
@@ -36,82 +48,74 @@ class UserTenantIT extends AbstractRestTestNoData {
     userTenantClient = new UserTenantClient(okapiUrl, okapiHeaders);
   }
 
-  @Test
-  void canCreateUserTenant() {
-    //when
+  @BeforeEach
+  public void beforeEach() {
     sendAffiliationCreatedEvent();
-    //then
-    UserTenantCollection collection = userTenantClient.getAllUsersTenants();
-    Assertions.assertEquals(1, collection.getTotalRecords());
-    UserTenant userTenant = collection.getUserTenants().iterator().next();
-    Assertions.assertNull(userTenant.getIsPrimary());
-    Assertions.assertNull(userTenant.getTenantName());
-    Assertions.assertEquals(USER_AFFILIATION.getId(), userTenant.getId());
-    Assertions.assertEquals(USER_AFFILIATION.getUserId(), userTenant.getUserId());
-    Assertions.assertEquals(USER_AFFILIATION.getUserName(), userTenant.getUserName());
-    Assertions.assertEquals(USER_AFFILIATION.getTenantId(), userTenant.getTenantId());
+    awaitHandlingEvent(3);
   }
 
   @Test
-  void canSearchByUserName() {
-    //given
-    String username = USER_AFFILIATION.getUserName();
-    Map<String, String> params = Map.of("username", username);
-    //when
-    sendAffiliationCreatedEvent();
-    //then
-    UserTenantCollection collection = userTenantClient.getUserTenants(params);
-    UserTenant userTenant = collection.getUserTenants().iterator().next();
-    Assertions.assertEquals(1, collection.getTotalRecords());
-    Assertions.assertEquals(username, userTenant.getUserName());
+  void canRetrieveAllUserTenants() {
+    UserTenantCollection collection = userTenantClient.getAllUsersTenants();
+
+    Assertions.assertEquals(3, collection.getTotalRecords());
   }
 
   @Test
   void canSearchByUserId() {
-    //given
-    String userId = USER_AFFILIATION.getUserId();
+    String userId = SECOND_AFFILIATION.getUserId();
     Map<String, String> params = Map.of("userId", userId);
-    //when
-    sendAffiliationCreatedEvent();
-    //then
+
     UserTenantCollection collection = userTenantClient.getUserTenants(params);
+
     UserTenant userTenant = collection.getUserTenants().iterator().next();
     Assertions.assertEquals(1, collection.getTotalRecords());
     Assertions.assertEquals(userId, userTenant.getUserId());
   }
 
   @Test
+  void canSearchByUserName() {
+    Map<String, String> params = Map.of("username", USER_A);
+
+    UserTenantCollection collection = userTenantClient.getUserTenants(params);
+
+    List<UserTenant> userTenants = collection.getUserTenants();
+    Assertions.assertEquals(2, collection.getTotalRecords());
+    userTenants.forEach(userTenant -> Assertions.assertEquals(USER_A, userTenant.getUserName()));
+  }
+
+  @Test
   void canSearchByUserNameAndTenantId() {
-    //given
-    String username = USER_AFFILIATION.getUserName();
-    String tenantId = USER_AFFILIATION.getTenantId();
+    String username = THIRD_AFFILIATION.getUserName();
+    String tenantId = THIRD_AFFILIATION.getTenantId();
     Map<String, String> params = Map.of(
       "username", username,
       "tenantId", tenantId);
-    //when
-    sendAffiliationCreatedEvent();
-    //then
+
     UserTenantCollection collection = userTenantClient.getUserTenants(params);
+
     Assertions.assertEquals(1, collection.getTotalRecords());
     UserTenant userTenant = collection.getUserTenants().iterator().next();
     Assertions.assertEquals(username, userTenant.getUserName());
     Assertions.assertEquals(tenantId, userTenant.getTenantId());
   }
 
-  private void awaitHandlingEvent() {
+  private void awaitHandlingEvent(int expectedSize) {
     Awaitility.await()
       .atMost(1, TimeUnit.MINUTES)
       .pollInterval(5, TimeUnit.SECONDS)
       .until(() -> {
         UserTenantCollection collection = userTenantClient.getAllUsersTenants();
-        return CollectionUtils.isNotEmpty(collection.getUserTenants());
+        return collection.getTotalRecords() == expectedSize;
       });
   }
 
   private void sendAffiliationCreatedEvent() {
-    String eventPayload = Json.encode(USER_AFFILIATION);
-    sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName(),
-      USER_AFFILIATION.getId(), eventPayload);
-    awaitHandlingEvent();
+    for (UserTenant userTenant : List.of(FIRST_AFFILIATION, SECOND_AFFILIATION, THIRD_AFFILIATION)) {
+      String eventPayload = Json.encode(userTenant);
+      sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName(),
+        userTenant.getId(), eventPayload);
+    }
+    awaitHandlingEvent(3);
   }
 }

--- a/src/test/java/org/folio/rest/impl/UserTenantITTest.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantITTest.java
@@ -1,0 +1,112 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.json.Json;
+import io.vertx.junit5.VertxExtension;
+import lombok.SneakyThrows;
+import org.apache.commons.collections4.CollectionUtils;
+import org.folio.event.ConsortiumEventType;
+import org.folio.moduserstest.AbstractRestTest;
+import org.folio.rest.jaxrs.model.UserTenant;
+import org.folio.rest.jaxrs.model.UserTenantCollection;
+import org.folio.support.http.UserTenantClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@ExtendWith(VertxExtension.class)
+class UserTenantITTest extends AbstractRestTest {
+
+  private static UserTenantClient userTenantClient;
+  private static final UserTenant USER_AFFILIATION =  new UserTenant()
+    .withId(UUID.randomUUID().toString())
+    .withUserId(UUID.randomUUID().toString())
+    .withUserName("folio_user")
+    .withTenantId("folio_tenant");
+
+  @BeforeAll
+  @SneakyThrows
+  static void beforeAll() {
+    userTenantClient = new UserTenantClient(okapiUrl, okapiHeaders);
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    LOAD_SAMPLE_DATA = false;
+    LOAD_REFERENCE_DATA = false;
+  }
+
+  @Test
+  void canCreateUserTenant() {
+    //given
+    String eventPayload = Json.encode(USER_AFFILIATION);
+    //when
+    sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName(),
+      USER_AFFILIATION.getId(), eventPayload);
+    awaitHandlingEvent();
+    //then
+    UserTenantCollection collection = userTenantClient.getAllUsersTenants();
+    Assertions.assertEquals(1, collection.getTotalRecords());
+    UserTenant userTenant = collection.getUserTenants().iterator().next();
+    Assertions.assertNull(userTenant.getIsPrimary());
+    Assertions.assertNull(userTenant.getTenantName());
+    Assertions.assertEquals(USER_AFFILIATION.getId(), userTenant.getId());
+    Assertions.assertEquals(USER_AFFILIATION.getUserId(), userTenant.getUserId());
+    Assertions.assertEquals(USER_AFFILIATION.getUserName(), userTenant.getUserName());
+    Assertions.assertEquals(USER_AFFILIATION.getTenantId(), userTenant.getTenantId());
+  }
+
+  @Test
+  void canSearchByUserName() {
+    //given
+    String username = USER_AFFILIATION.getUserName();
+    String eventPayload = Json.encode(USER_AFFILIATION);
+    Map<String, String> params = Map.of("username", username);
+    //when
+    sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName(),
+      USER_AFFILIATION.getId(), eventPayload);
+    awaitHandlingEvent();
+    //then
+    UserTenantCollection collection = userTenantClient.getUserTenants(params);
+    UserTenant userTenant = collection.getUserTenants().iterator().next();
+    Assertions.assertEquals(1, collection.getTotalRecords());
+    Assertions.assertEquals(username, userTenant.getUserName());
+  }
+
+  @Test
+  void canSearchByUserNameAndTenantId() {
+    //given
+    String username = USER_AFFILIATION.getUserName();
+    String tenantId = USER_AFFILIATION.getTenantId();
+    Map<String, String> params = Map.of(
+      "username", username,
+      "tenantId", tenantId);
+    String eventPayload = Json.encode(USER_AFFILIATION);
+    //when
+    sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_CREATED.getTopicName(),
+      USER_AFFILIATION.getId(), eventPayload);
+    awaitHandlingEvent();
+    //then
+    UserTenantCollection collection = userTenantClient.getUserTenants(params);
+    Assertions.assertEquals(1, collection.getTotalRecords());
+    UserTenant userTenant = collection.getUserTenants().iterator().next();
+    Assertions.assertEquals(username, userTenant.getUserName());
+    Assertions.assertEquals(tenantId, userTenant.getTenantId());
+  }
+
+  private void awaitHandlingEvent() {
+    Awaitility.await()
+      .atMost(1, TimeUnit.MINUTES)
+      .pollInterval(5, TimeUnit.SECONDS)
+      .until(() -> {
+        UserTenantCollection collection = userTenantClient.getAllUsersTenants();
+        return CollectionUtils.isNotEmpty(collection.getUserTenants());
+      });
+  }
+}

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -58,8 +58,6 @@ class UsersAPIIT extends AbstractRestTest {
 
   @BeforeEach
   public void beforeEach() {
-    LOAD_SAMPLE_DATA = false;
-    LOAD_REFERENCE_DATA = false;
     usersClient.deleteAllUsers();
     groupsClient.deleteAllGroups();
     addressTypesClient.deleteAllAddressTypes();

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -5,6 +5,7 @@ import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.event.UserEventType.USER_CREATED;
+import org.folio.moduserstest.AbstractRestTestNoData;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -19,7 +20,6 @@ import java.util.List;
 import java.util.UUID;
 
 import io.vertx.core.json.Json;
-import org.folio.moduserstest.AbstractRestTest;
 import org.folio.rest.jaxrs.model.UserEvent;
 import org.folio.support.Address;
 import org.folio.support.AddressType;
@@ -42,7 +42,7 @@ import lombok.SneakyThrows;
 
 @Timeout(value = 20, timeUnit = SECONDS)
 @ExtendWith(VertxExtension.class)
-class UsersAPIIT extends AbstractRestTest {
+class UsersAPIIT extends AbstractRestTestNoData {
 
   private static UsersClient usersClient;
   private static GroupsClient groupsClient;

--- a/src/test/java/org/folio/support/http/UserTenantClient.java
+++ b/src/test/java/org/folio/support/http/UserTenantClient.java
@@ -1,0 +1,32 @@
+package org.folio.support.http;
+
+import org.folio.rest.jaxrs.model.UserTenantCollection;
+
+import java.util.Map;
+
+public class UserTenantClient {
+  private final RestAssuredConfiguration configuration;
+
+  public UserTenantClient(OkapiUrl okapiUrl, OkapiHeaders defaultHeaders) {
+    configuration = new RestAssuredConfiguration(okapiUrl.asURI("/user-tenants"), defaultHeaders);
+  }
+
+  public UserTenantCollection getUserTenants(Map<String, String> queryParams) {
+    return configuration.initialSpecification()
+      .when()
+      .queryParams(queryParams)
+      .get()
+      .then()
+      .extract().as(UserTenantCollection.class);
+  }
+
+  public UserTenantCollection getAllUsersTenants() {
+    return configuration.initialSpecification()
+      .when()
+      .queryParams("limit", Integer.MAX_VALUE)
+      .get()
+      .then()
+      .extract().as(UserTenantCollection.class);
+  }
+
+}


### PR DESCRIPTION
## Purpose
We need to implement a consumer of CONSORTIUM_PRIMARY_AFFILIATION_CREATED event that is produced by mod-consortia module. This event will include userId, username, tenantId in the payload and these data should be stored in user_tenant table in mod-login.

## Approach
- Implemented kafka consumer for event: CONSORTIUM_PRIMARY_AFFILIATION_CREATED
- Implemented endpoint to retrieve saved user affiliations

## Learning
[MODUSERS-354](https://issues.folio.org/browse/MODUSERS-354)

