### PR TITLE
[MODUSERS-364] Create Post user-tenant endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -222,6 +222,11 @@
           "methods": [ "GET" ],
           "pathPattern": "/user-tenants",
           "permissionsRequired": [ "user-tenants.collection.get" ]
+        },
+        {
+          "methods": [ "POST" ],
+          "pathPattern": "/user-tenants",
+          "permissionsRequired": [ "user-tenants.item.post" ]
         }
       ]
     },
@@ -424,6 +429,11 @@
       "description" : "Get a list of user-tenants records"
     },
     {
+      "permissionName" : "user-tenants.item.post",
+      "displayName" : "user-tenants item post",
+      "description" : "Create a new user-tenant record"
+    },
+    {
       "permissionName" : "users.all",
       "displayName" : "users all",
       "description" : "All permissions for the mod-users module",
@@ -459,7 +469,8 @@
         "patron-pin.set",
         "patron-pin.delete",
         "patron-pin.validate",
-        "user-tenants.collection.get"
+        "user-tenants.collection.get",
+        "user-tenants.item.post"
       ]
     },{
       "permissionName": "user-settings.custom-fields.collection.get",

--- a/ramls/userTenants.raml
+++ b/ramls/userTenants.raml
@@ -60,10 +60,10 @@ resourceTypes:
             example: "Internal server error"
   post:
     is: [ validate ]
-    description: Create a user tenant
+    description: Create a user-tenant
     responses:
-      204:
-        description: "No content"
+      201:
+        description: "Returns only 201 status code without body"
       500:
         description: "Internal server error"
         body:

--- a/ramls/userTenants.raml
+++ b/ramls/userTenants.raml
@@ -64,6 +64,12 @@ resourceTypes:
     responses:
       201:
         description: "Returns only 201 status code without body"
+      400:
+        description: "Bad request, e.g. malformed request body. Details of the error provided in the response."
+      401:
+        description: "Not authorized to perform requested action"
+      422:
+        description: "Validation error, e.g. missing required field. Details of the error provided in the response."
       500:
         description: "Internal server error"
         body:

--- a/ramls/userTenants.raml
+++ b/ramls/userTenants.raml
@@ -17,12 +17,12 @@ traits:
   language: !include raml-util/traits/language.raml
 
 resourceTypes:
-  collection-get: !include raml-util/rtypes/collection-get.raml
-  collection-item-get: !include raml-util/rtypes/item-collection-get.raml
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
 
 /user-tenants:
   type:
-    collection-get:
+    collection:
       exampleCollection: !include examples/userTenantCollection.sample
       exampleItem: !include examples/userTenant.sample
       schemaCollection: userTenantCollection
@@ -53,6 +53,17 @@ resourceTypes:
         body:
           application/json:
             type: userTenantCollection
+      500:
+        description: "Internal server error"
+        body:
+          text/plain:
+            example: "Internal server error"
+  post:
+    is: [ validate ]
+    description: Create a user tenant
+    responses:
+      204:
+        description: "No content"
       500:
         description: "Internal server error"
         body:

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -5,6 +5,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.event.service.UserTenantService;
+import org.folio.rest.jaxrs.model.UserTenant;
 import org.folio.rest.jaxrs.resource.UserTenants;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
@@ -41,6 +42,18 @@ public class UserTenantsAPI implements UserTenants {
         succeededFuture(GetUserTenantsResponse.respond200WithApplicationJson(res))))
       .onFailure(cause -> asyncResultHandler.handle(
         succeededFuture(GetUserTenantsResponse.respond500WithTextPlain(cause.getMessage()))));
+  }
+
+  @Override
+  public void postUserTenants(String lang, UserTenant userTenant, Map<String, String> okapiHeaders,
+                              Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    String okapiTenantId = TenantTool.tenantId(okapiHeaders);
+
+    userTenantService.saveUserTenant(userTenant, okapiTenantId, vertxContext.owner())
+      .onSuccess(res -> asyncResultHandler.handle(
+        succeededFuture(Response.noContent().build())))
+      .onFailure(cause -> asyncResultHandler.handle(
+        succeededFuture(PostUserTenantsResponse.respond500WithTextPlain(cause.getMessage()))));
   }
 
   private void addWhereClauseArgumentsToCriterion(String userId, String username, String tenantId, Criterion criterion) {

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -43,15 +43,12 @@ public class UserTenantsAPI implements UserTenants {
 
     userTenantService.fetchUserTenants(okapiTenantId, criterion, vertxContext.owner())
       .onSuccess(res -> {
-        logger.info("Number of existing user-tenant records: {}.", res.getTotalRecords());
-        asyncResultHandler.handle(
-          succeededFuture(GetUserTenantsResponse.respond200WithApplicationJson(res)));
+        logger.debug("Number of existing user-tenant records: {}.", res.getTotalRecords());
+        asyncResultHandler.handle(succeededFuture(GetUserTenantsResponse.respond200WithApplicationJson(res)));
       })
       .onFailure(cause -> {
-        String message = cause.getLocalizedMessage();
-        logger.error(message, cause);
-        asyncResultHandler.handle(
-          succeededFuture(GetUserTenantsResponse.respond500WithTextPlain(cause.getMessage())));
+        logger.error("Could not get user-tenant records", cause);
+        asyncResultHandler.handle(succeededFuture(GetUserTenantsResponse.respond500WithTextPlain(cause.getMessage())));
       });
   }
 
@@ -66,14 +63,11 @@ public class UserTenantsAPI implements UserTenants {
       .onSuccess(res -> {
         logger.info("user-tenant with id: {}, userId: {}, userName: {}, tenantId: {} has been saved successfully.",
           userTenant.getId(), userTenant.getUserId(), userTenant.getUserName(), userTenant.getTenantId());
-        asyncResultHandler.handle(
-          succeededFuture(Response.status(201).build()));
+        asyncResultHandler.handle(succeededFuture(Response.status(201).build()));
       })
       .onFailure(cause -> {
-        String message = cause.getLocalizedMessage();
-        logger.error(message, cause);
-        asyncResultHandler.handle(
-          succeededFuture(PostUserTenantsResponse.respond500WithTextPlain(cause.getMessage())));
+        logger.error("Could not save user-tenant record", cause);
+        asyncResultHandler.handle(succeededFuture(PostUserTenantsResponse.respond500WithTextPlain(cause.getMessage())));
       });
   }
 

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -118,17 +118,35 @@ class UserTenantIT extends AbstractRestTestNoData {
 
   @Test
   void canCreateAUserTenant() {
-    UserTenantCollection collection1 = userTenantClient.getAllUsersTenants();
+    UserTenantCollection collection = userTenantClient.getAllUsersTenants();
 
-    Assertions.assertEquals(3, collection1.getTotalRecords());
-    Assertions.assertFalse(collection1.getUserTenants().contains(FOURTH_AFFILIATION));
+    Assertions.assertEquals(3, collection.getTotalRecords());
+    Assertions.assertFalse(collection.getUserTenants().contains(FOURTH_AFFILIATION));
 
-    userTenantClient.saveUserTenant(FOURTH_AFFILIATION);
-    UserTenantCollection collection2 = userTenantClient.getAllUsersTenants();
+    userTenantClient.attemptToSaveUserTenant(FOURTH_AFFILIATION, 201);
+    collection = userTenantClient.getAllUsersTenants();
 
-    Assertions.assertEquals(4, collection2.getTotalRecords());
-    Assertions.assertTrue(collection2.getUserTenants().contains(FOURTH_AFFILIATION));
-    sendAffiliationDeletedEvents(collection2.getUserTenants());
+    Assertions.assertEquals(4, collection.getTotalRecords());
+    Assertions.assertTrue(collection.getUserTenants().contains(FOURTH_AFFILIATION));
+    sendAffiliationDeletedEvents(collection.getUserTenants());
+  }
+
+  @Test
+  void shouldGet422ForMissingRequiredFields() {
+    userTenantClient.attemptToSaveUserTenant(new UserTenant(), 422);
+  }
+
+  @Test
+  void shouldGet500WhenTryingToSaveAlreadyExistingRecord() {
+    UserTenantCollection collection = userTenantClient.getAllUsersTenants();
+
+    Assertions.assertEquals(3, collection.getTotalRecords());
+    Assertions.assertTrue(collection.getUserTenants().contains(FIRST_AFFILIATION));
+
+    userTenantClient.attemptToSaveUserTenant(FIRST_AFFILIATION, 500);
+    collection = userTenantClient.getAllUsersTenants();
+
+    Assertions.assertEquals(3, collection.getTotalRecords());
   }
 
   private void awaitHandlingEvent(int expectedSize) {

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -123,7 +123,9 @@ class UserTenantIT extends AbstractRestTestNoData {
     Assertions.assertEquals(3, collection.getTotalRecords());
     Assertions.assertFalse(collection.getUserTenants().contains(FOURTH_AFFILIATION));
 
-    userTenantClient.attemptToSaveUserTenant(FOURTH_AFFILIATION, 201);
+    int actualStatusCode = userTenantClient.attemptToSaveUserTenant(FOURTH_AFFILIATION);
+    Assertions.assertEquals(201, actualStatusCode);
+
     collection = userTenantClient.getAllUsersTenants();
 
     Assertions.assertEquals(4, collection.getTotalRecords());
@@ -133,7 +135,8 @@ class UserTenantIT extends AbstractRestTestNoData {
 
   @Test
   void shouldGet422ForMissingRequiredFields() {
-    userTenantClient.attemptToSaveUserTenant(new UserTenant(), 422);
+    int actualStatusCode = userTenantClient.attemptToSaveUserTenant(new UserTenant());
+    Assertions.assertEquals(422, actualStatusCode);
   }
 
   @Test
@@ -143,7 +146,9 @@ class UserTenantIT extends AbstractRestTestNoData {
     Assertions.assertEquals(3, collection.getTotalRecords());
     Assertions.assertTrue(collection.getUserTenants().contains(FIRST_AFFILIATION));
 
-    userTenantClient.attemptToSaveUserTenant(FIRST_AFFILIATION, 500);
+    int actualStatusCode = userTenantClient.attemptToSaveUserTenant(FIRST_AFFILIATION);
+    Assertions.assertEquals(500, actualStatusCode);
+
     collection = userTenantClient.getAllUsersTenants();
 
     Assertions.assertEquals(3, collection.getTotalRecords());

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -41,6 +41,10 @@ class UserTenantIT extends AbstractRestTestNoData {
     .withId(UUID.randomUUID().toString())
     .withUserId(UUID.randomUUID().toString())
     .withUserName(USER_A).withTenantId(TENANT_Y);
+  private static final UserTenant FOURTH_AFFILIATION = new UserTenant()
+    .withId(UUID.randomUUID().toString())
+    .withUserId(UUID.randomUUID().toString())
+    .withUserName(USER_B).withTenantId(TENANT_Y);
 
   @BeforeAll
   @SneakyThrows
@@ -66,7 +70,8 @@ class UserTenantIT extends AbstractRestTestNoData {
     UserTenantCollection collection = userTenantClient.getAllUsersTenants();
 
     Assertions.assertEquals(3, collection.getTotalRecords());
-    sendAffiliationDeletedEvents();
+
+    sendAffiliationDeletedEvents(collection.getUserTenants());
     UserTenantCollection collection2 = userTenantClient.getAllUsersTenants();
 
     Assertions.assertEquals(0, collection2.getTotalRecords());
@@ -111,6 +116,21 @@ class UserTenantIT extends AbstractRestTestNoData {
     Assertions.assertEquals(tenantId, userTenant.getTenantId());
   }
 
+  @Test
+  void canCreateAUserTenant() {
+    UserTenantCollection collection1 = userTenantClient.getAllUsersTenants();
+
+    Assertions.assertEquals(3, collection1.getTotalRecords());
+    Assertions.assertFalse(collection1.getUserTenants().contains(FOURTH_AFFILIATION));
+
+    userTenantClient.saveUserTenant(FOURTH_AFFILIATION);
+    UserTenantCollection collection2 = userTenantClient.getAllUsersTenants();
+
+    Assertions.assertEquals(4, collection2.getTotalRecords());
+    Assertions.assertTrue(collection2.getUserTenants().contains(FOURTH_AFFILIATION));
+    sendAffiliationDeletedEvents(collection2.getUserTenants());
+  }
+
   private void awaitHandlingEvent(int expectedSize) {
     Awaitility.await()
       .atMost(1, TimeUnit.MINUTES)
@@ -130,8 +150,8 @@ class UserTenantIT extends AbstractRestTestNoData {
     awaitHandlingEvent(3);
   }
 
-  private void sendAffiliationDeletedEvents() {
-    for (UserTenant userTenant : List.of(FIRST_AFFILIATION, SECOND_AFFILIATION, THIRD_AFFILIATION)) {
+  private void sendAffiliationDeletedEvents(List<UserTenant> userTenants) {
+    for (UserTenant userTenant : userTenants) {
       String eventPayload = Json.encode(userTenant);
       sendEvent(TENANT_NAME, ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION_DELETED.getTopicName(),
         userTenant.getId(), eventPayload);

--- a/src/test/java/org/folio/support/http/UserTenantClient.java
+++ b/src/test/java/org/folio/support/http/UserTenantClient.java
@@ -5,9 +5,6 @@ import org.folio.rest.jaxrs.model.UserTenantCollection;
 
 import java.util.Map;
 
-import static io.restassured.http.ContentType.JSON;
-import static java.net.HttpURLConnection.HTTP_CREATED;
-
 public class UserTenantClient {
   private final RestAssuredConfiguration configuration;
 
@@ -33,13 +30,13 @@ public class UserTenantClient {
       .extract().as(UserTenantCollection.class);
   }
 
-  public void saveUserTenant(UserTenant userTenant) {
+  public void attemptToSaveUserTenant(UserTenant userTenant, int expectedStatusCode) {
     configuration.initialSpecification()
-      .contentType(JSON)
+      .contentType("application/json")
       .when()
       .body(userTenant)
       .post()
       .then()
-      .statusCode(HTTP_CREATED);
+      .statusCode(expectedStatusCode);
   }
 }

--- a/src/test/java/org/folio/support/http/UserTenantClient.java
+++ b/src/test/java/org/folio/support/http/UserTenantClient.java
@@ -30,13 +30,13 @@ public class UserTenantClient {
       .extract().as(UserTenantCollection.class);
   }
 
-  public void attemptToSaveUserTenant(UserTenant userTenant, int expectedStatusCode) {
-    configuration.initialSpecification()
+  public int attemptToSaveUserTenant(UserTenant userTenant) {
+    return configuration.initialSpecification()
       .contentType("application/json")
       .when()
       .body(userTenant)
       .post()
       .then()
-      .statusCode(expectedStatusCode);
+      .extract().statusCode();
   }
 }

--- a/src/test/java/org/folio/support/http/UserTenantClient.java
+++ b/src/test/java/org/folio/support/http/UserTenantClient.java
@@ -6,7 +6,7 @@ import org.folio.rest.jaxrs.model.UserTenantCollection;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
-import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
+import static java.net.HttpURLConnection.HTTP_CREATED;
 
 public class UserTenantClient {
   private final RestAssuredConfiguration configuration;
@@ -40,6 +40,6 @@ public class UserTenantClient {
       .body(userTenant)
       .post()
       .then()
-      .statusCode(HTTP_NO_CONTENT);
+      .statusCode(HTTP_CREATED);
   }
 }

--- a/src/test/java/org/folio/support/http/UserTenantClient.java
+++ b/src/test/java/org/folio/support/http/UserTenantClient.java
@@ -1,8 +1,12 @@
 package org.folio.support.http;
 
+import org.folio.rest.jaxrs.model.UserTenant;
 import org.folio.rest.jaxrs.model.UserTenantCollection;
 
 import java.util.Map;
+
+import static io.restassured.http.ContentType.JSON;
+import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 
 public class UserTenantClient {
   private final RestAssuredConfiguration configuration;
@@ -29,4 +33,13 @@ public class UserTenantClient {
       .extract().as(UserTenantCollection.class);
   }
 
+  public void saveUserTenant(UserTenant userTenant) {
+    configuration.initialSpecification()
+      .contentType(JSON)
+      .when()
+      .body(userTenant)
+      .post()
+      .then()
+      .statusCode(HTTP_NO_CONTENT);
+  }
 }


### PR DESCRIPTION
Resolves [MODUSERS-364](https://issues.folio.org/browse/MODUSERS-364) Create Post user-tenant endpoint
We need this for new approach in mod-authtoken
- After adding some institutional tenant to Consortium mod-consortia will invoke POST endpoint implemented here to create some dummy user tenant record
- Mod-authtoken will call GET /user-tenant endpoint in the institutional tenant to check totalRecords(in case when tenant in header not matches with tenant in token). If totalRecords > 0 - mod-authtoken will allow the cross-tenant request