### PR TITLE
[MODUSERS-370] Modify users dtos to include source field

### DIFF
--- a/ramls/department.json
+++ b/ramls/department.json
@@ -27,7 +27,7 @@
       "readonly": true
     },
     "source": {
-      "description": "origin of the department record, i.e. 'System' or 'User'",
+      "description": "Origin of the department record, i.e. 'System' or 'User'",
       "type": "string"
     },
     "metadata": {

--- a/ramls/department.json
+++ b/ramls/department.json
@@ -26,6 +26,10 @@
       "description": "Number of users that have this department",
       "readonly": true
     },
+    "source": {
+      "description": "origin of the department record, i.e. 'System' or 'User'",
+      "type": "string"
+    },
     "metadata": {
       "description": "Metadata about creation and changes to department records",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/ramls/examples/department.sample
+++ b/ramls/examples/department.sample
@@ -2,5 +2,6 @@
   "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d",
   "name": "Accounting",
   "code": "ACC",
-  "usageNumber": 10
+  "usageNumber": 10,
+  "source": "System"
 }

--- a/ramls/examples/departmentCollection.sample
+++ b/ramls/examples/departmentCollection.sample
@@ -4,13 +4,15 @@
       "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d",
       "name": "Accounting",
       "code": "ACC",
-      "usageNumber": 0
+      "usageNumber": 0,
+      "source": "System"
     },
     {
       "id": "4bb563d9-3f9d-4e1e-8d1d-04e75666d68f",
       "name": "History",
       "code": "HIS",
-      "usageNumber": 2
+      "usageNumber": 2,
+      "source": "System"
     }
   ],
   "totalRecords": 2

--- a/ramls/examples/group.sample
+++ b/ramls/examples/group.sample
@@ -2,5 +2,6 @@
   "group": "librarian",
   "desc": "basic lib group",
   "expirationOffsetInDays": 365,
-  "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d"
+  "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d",
+  "source": "System"
 }

--- a/ramls/examples/groups.sample
+++ b/ramls/examples/groups.sample
@@ -4,12 +4,14 @@
       "group": "librarian",
       "desc": "basic lib group",
       "expirationOffsetInDays": 365,
-      "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d"
+      "id": "b4b5e97a-0a99-4db9-97df-4fdf406ec74d",
+      "source": "System"
     },
     {
       "group": "on_campus_patrons",
       "desc": "On-campus patrons",
-      "id": "4bb563d9-3f9d-4e1e-8d1d-04e75666d68f"
+      "id": "4bb563d9-3f9d-4e1e-8d1d-04e75666d68f",
+      "source": "System"
     }
   ],
   "totalRecords": 2

--- a/ramls/usergroup.json
+++ b/ramls/usergroup.json
@@ -20,6 +20,10 @@
       "description": "The default period in days after which a newly created user that belongs to this group will expire",
       "type": "integer"
     },
+    "source": {
+      "description": "origin of the group record, i.e. 'System' or 'User'",
+      "type": "string"
+    },
     "metadata": {
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly": true

--- a/ramls/usergroup.json
+++ b/ramls/usergroup.json
@@ -21,7 +21,7 @@
       "type": "integer"
     },
     "source": {
-      "description": "origin of the group record, i.e. 'System' or 'User'",
+      "description": "Origin of the group record, i.e. 'System' or 'User'",
       "type": "string"
     },
     "metadata": {


### PR DESCRIPTION
Resolves: [MODCON-66](https://issues.folio.org/browse/MODUSERS-370) Modify users dtos to include source field.

This table describes what setting we are going to implement in Consortium Manager:
https://wiki.folio.org/display/FOLIJET/Consortium+manager+settings
So for _mod-users_ it is _departments_ and _patron groups_.
Setting created in Consortium Manager will have value 'Consortium' and we will add validation to prevent updating them