### PR TITLE
[MODUSERBL-169] - getUserTenants criterion changed to or

### DIFF
--- a/ramls/userTenants.raml
+++ b/ramls/userTenants.raml
@@ -63,6 +63,10 @@ resourceTypes:
         type: string
         example: "123456789"
         required: false
+      queryOp:
+        description: Whether to use 'or' in criteria
+        type: boolean
+        default: false
     responses:
       200:
         body:

--- a/ramls/userTenants.raml
+++ b/ramls/userTenants.raml
@@ -63,8 +63,8 @@ resourceTypes:
         type: string
         example: "123456789"
         required: false
-      queryCriteria:
-        description: Criteria for search query
+      queryOp:
+        description: Query operation for searching
         type: string
         default: "and"
     responses:

--- a/ramls/userTenants.raml
+++ b/ramls/userTenants.raml
@@ -63,10 +63,10 @@ resourceTypes:
         type: string
         example: "123456789"
         required: false
-      queryOp:
-        description: Whether to use 'or' in criteria
-        type: boolean
-        default: false
+      queryCriteria:
+        description: Criteria for search query
+        type: string
+        default: "and"
     responses:
       200:
         body:

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -87,6 +87,6 @@ public class UserTenantsAPI implements UserTenants {
     fields.entrySet().stream()
       .filter(entry -> StringUtils.isNotBlank(entry.getValue()))
       .map(entry -> new Criteria().addField(entry.getKey()).setOperation("=").setVal(entry.getValue()).setJSONB(false))
-      .forEach(criterion::addCriterion);
+      .forEach(a -> criterion.addCriterion(a, "or"));
   }
 }

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -36,12 +36,12 @@ public class UserTenantsAPI implements UserTenants {
   }
 
   @Override
-  public void getUserTenants(String userId, String username, String tenantId, String email, String phoneNumber, String mobilePhoneNumber, String queryCriteria, int offset, int limit, String lang,
+  public void getUserTenants(String userId, String username, String tenantId, String email, String phoneNumber, String mobilePhoneNumber, String queryOp, int offset, int limit, String lang,
                              Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
                              Context vertxContext) {
     String okapiTenantId = TenantTool.tenantId(okapiHeaders);
     Criterion criterion = new Criterion().setLimit(new Limit(limit)).setOffset(new Offset(offset));
-    addWhereClauseArgumentsToCriterion(userId, username, tenantId, email, phoneNumber, mobilePhoneNumber, queryCriteria, criterion);
+    addWhereClauseArgumentsToCriterion(userId, username, tenantId, email, phoneNumber, mobilePhoneNumber, queryOp, criterion);
     logger.debug("Trying to get user-tenant records with criterion: {}.", criterion);
 
     userTenantService.fetchUserTenants(okapiTenantId, criterion, vertxContext.owner())
@@ -75,7 +75,7 @@ public class UserTenantsAPI implements UserTenants {
   }
 
   private void addWhereClauseArgumentsToCriterion(String userId, String username, String tenantId, String email,
-                                                  String phoneNumber, String mobilePhoneNumber, String queryCriteria, Criterion criterion) {
+                                                  String phoneNumber, String mobilePhoneNumber, String queryOp, Criterion criterion) {
     Map<String, String> fields = Map.of(
       USER_ID_FIELD, StringUtils.defaultString(userId),
       USERNAME_FIELD, StringUtils.defaultString(username),
@@ -88,6 +88,6 @@ public class UserTenantsAPI implements UserTenants {
     fields.entrySet().stream()
       .filter(entry -> StringUtils.isNotBlank(entry.getValue()))
       .map(entry -> new Criteria().addField(entry.getKey()).setOperation("=").setVal(entry.getValue()).setJSONB(false))
-      .forEach(param -> criterion.addCriterion(param, queryCriteria));
+      .forEach(param -> criterion.addCriterion(param, queryOp));
   }
 }

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -41,8 +41,8 @@ public class UserTenantsAPI implements UserTenants {
                              Context vertxContext) {
     String okapiTenantId = TenantTool.tenantId(okapiHeaders);
     Criterion criterion = new Criterion().setLimit(new Limit(limit)).setOffset(new Offset(offset));
-    ArgumentsToCriterion argumentsToCriterion = new ArgumentsToCriterion(userId, username, tenantId, email, phoneNumber, mobilePhoneNumber);
-    addWhereClauseArgumentsToCriterion(argumentsToCriterion, queryOp, criterion);
+    ArgumentsHolder argumentsHolder = new ArgumentsHolder(userId, username, tenantId, email, phoneNumber, mobilePhoneNumber);
+    addWhereClauseArgumentsToCriterion(argumentsHolder, queryOp, criterion);
     logger.debug("Trying to get user-tenant records with criterion: {}.", criterion);
 
     userTenantService.fetchUserTenants(okapiTenantId, criterion, vertxContext.owner())
@@ -75,14 +75,14 @@ public class UserTenantsAPI implements UserTenants {
       });
   }
 
-  private void addWhereClauseArgumentsToCriterion(ArgumentsToCriterion argumentsToCriterion, String queryOp, Criterion criterion) {
+  private void addWhereClauseArgumentsToCriterion(ArgumentsHolder argumentsHolder, String queryOp, Criterion criterion) {
     Map<String, String> fields = Map.of(
-      USER_ID_FIELD, StringUtils.defaultString(argumentsToCriterion.userId()),
-      USERNAME_FIELD, StringUtils.defaultString(argumentsToCriterion.username()),
-      TENANT_ID_FIELD, StringUtils.defaultString(argumentsToCriterion.tenantId()),
-      EMAIL, StringUtils.defaultString(argumentsToCriterion.email()),
-      PHONE_NUMBER, StringUtils.defaultString(argumentsToCriterion.phoneNumber()),
-      MOBILE_PHONE_NUMBER, StringUtils.defaultString(argumentsToCriterion.mobilePhoneNumber())
+      USER_ID_FIELD, StringUtils.defaultString(argumentsHolder.userId()),
+      USERNAME_FIELD, StringUtils.defaultString(argumentsHolder.username()),
+      TENANT_ID_FIELD, StringUtils.defaultString(argumentsHolder.tenantId()),
+      EMAIL, StringUtils.defaultString(argumentsHolder.email()),
+      PHONE_NUMBER, StringUtils.defaultString(argumentsHolder.phoneNumber()),
+      MOBILE_PHONE_NUMBER, StringUtils.defaultString(argumentsHolder.mobilePhoneNumber())
       );
 
     fields.entrySet().stream()
@@ -91,5 +91,5 @@ public class UserTenantsAPI implements UserTenants {
       .forEach(param -> criterion.addCriterion(param, queryOp));
   }
 
-  record ArgumentsToCriterion(String userId, String username, String tenantId, String email, String phoneNumber, String mobilePhoneNumber) {}
+  record ArgumentsHolder(String userId, String username, String tenantId, String email, String phoneNumber, String mobilePhoneNumber) {}
 }

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -36,12 +36,12 @@ public class UserTenantsAPI implements UserTenants {
   }
 
   @Override
-  public void getUserTenants(String userId, String username, String tenantId, String email, String phoneNumber, String mobilePhoneNumber, boolean queryOp, int offset, int limit, String lang,
+  public void getUserTenants(String userId, String username, String tenantId, String email, String phoneNumber, String mobilePhoneNumber, String queryCriteria, int offset, int limit, String lang,
                              Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
                              Context vertxContext) {
     String okapiTenantId = TenantTool.tenantId(okapiHeaders);
     Criterion criterion = new Criterion().setLimit(new Limit(limit)).setOffset(new Offset(offset));
-    addWhereClauseArgumentsToCriterion(userId, username, tenantId, email, phoneNumber, mobilePhoneNumber, queryOp, criterion);
+    addWhereClauseArgumentsToCriterion(userId, username, tenantId, email, phoneNumber, mobilePhoneNumber, queryCriteria, criterion);
     logger.debug("Trying to get user-tenant records with criterion: {}.", criterion);
 
     userTenantService.fetchUserTenants(okapiTenantId, criterion, vertxContext.owner())
@@ -75,7 +75,7 @@ public class UserTenantsAPI implements UserTenants {
   }
 
   private void addWhereClauseArgumentsToCriterion(String userId, String username, String tenantId, String email,
-                                                  String phoneNumber, String mobilePhoneNumber,  boolean queryOp, Criterion criterion) {
+                                                  String phoneNumber, String mobilePhoneNumber, String queryCriteria, Criterion criterion) {
     Map<String, String> fields = Map.of(
       USER_ID_FIELD, StringUtils.defaultString(userId),
       USERNAME_FIELD, StringUtils.defaultString(username),
@@ -88,10 +88,6 @@ public class UserTenantsAPI implements UserTenants {
     fields.entrySet().stream()
       .filter(entry -> StringUtils.isNotBlank(entry.getValue()))
       .map(entry -> new Criteria().addField(entry.getKey()).setOperation("=").setVal(entry.getValue()).setJSONB(false))
-      .forEach(a -> {
-        if (queryOp) {
-          criterion.addCriterion(a, "or");
-        }
-      });
+      .forEach(param -> criterion.addCriterion(param, queryCriteria));
   }
 }

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -41,7 +41,8 @@ public class UserTenantsAPI implements UserTenants {
                              Context vertxContext) {
     String okapiTenantId = TenantTool.tenantId(okapiHeaders);
     Criterion criterion = new Criterion().setLimit(new Limit(limit)).setOffset(new Offset(offset));
-    addWhereClauseArgumentsToCriterion(userId, username, tenantId, email, phoneNumber, mobilePhoneNumber, queryOp, criterion);
+    ArgumentsToCriterion argumentsToCriterion = new ArgumentsToCriterion(userId, username, tenantId, email, phoneNumber, mobilePhoneNumber);
+    addWhereClauseArgumentsToCriterion(argumentsToCriterion, queryOp, criterion);
     logger.debug("Trying to get user-tenant records with criterion: {}.", criterion);
 
     userTenantService.fetchUserTenants(okapiTenantId, criterion, vertxContext.owner())
@@ -74,15 +75,14 @@ public class UserTenantsAPI implements UserTenants {
       });
   }
 
-  private void addWhereClauseArgumentsToCriterion(String userId, String username, String tenantId, String email,
-                                                  String phoneNumber, String mobilePhoneNumber, String queryOp, Criterion criterion) {
+  private void addWhereClauseArgumentsToCriterion(ArgumentsToCriterion argumentsToCriterion, String queryOp, Criterion criterion) {
     Map<String, String> fields = Map.of(
-      USER_ID_FIELD, StringUtils.defaultString(userId),
-      USERNAME_FIELD, StringUtils.defaultString(username),
-      TENANT_ID_FIELD, StringUtils.defaultString(tenantId),
-      EMAIL, StringUtils.defaultString(email),
-      PHONE_NUMBER, StringUtils.defaultString(phoneNumber),
-      MOBILE_PHONE_NUMBER, StringUtils.defaultString(mobilePhoneNumber)
+      USER_ID_FIELD, StringUtils.defaultString(argumentsToCriterion.userId()),
+      USERNAME_FIELD, StringUtils.defaultString(argumentsToCriterion.username()),
+      TENANT_ID_FIELD, StringUtils.defaultString(argumentsToCriterion.tenantId()),
+      EMAIL, StringUtils.defaultString(argumentsToCriterion.email()),
+      PHONE_NUMBER, StringUtils.defaultString(argumentsToCriterion.phoneNumber()),
+      MOBILE_PHONE_NUMBER, StringUtils.defaultString(argumentsToCriterion.mobilePhoneNumber())
       );
 
     fields.entrySet().stream()
@@ -90,4 +90,6 @@ public class UserTenantsAPI implements UserTenants {
       .map(entry -> new Criteria().addField(entry.getKey()).setOperation("=").setVal(entry.getValue()).setJSONB(false))
       .forEach(param -> criterion.addCriterion(param, queryOp));
   }
+
+  record ArgumentsToCriterion(String userId, String username, String tenantId, String email, String phoneNumber, String mobilePhoneNumber) {}
 }

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -141,6 +141,19 @@ class UserTenantIT extends AbstractRestTestNoData {
   }
 
   @Test
+  void canSearchByUserNameAndTenantIdWithOrCriteria() {
+    String username = THIRD_AFFILIATION.getUsername();
+    String tenantId = THIRD_AFFILIATION.getTenantId();
+    Map<String, String> params = Map.of(
+      "username", username,
+      "tenantId", tenantId,
+      "queryCriteria", "or");
+
+    UserTenantCollection collection = userTenantClient.getUserTenants(params);
+    Assertions.assertEquals(2, collection.getTotalRecords());
+  }
+
+  @Test
   void canCreateAUserTenant() {
     UserTenantCollection collection = userTenantClient.getAllUsersTenants();
 

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -143,17 +143,13 @@ class UserTenantIT extends AbstractRestTestNoData {
   @Test
   void canSearchByUserNameAndTenantIdWithOrCriteria() {
     String username = THIRD_AFFILIATION.getUsername();
-    String tenantId = THIRD_AFFILIATION.getTenantId();
     Map<String, String> params = Map.of(
       "username", username,
       "tenantId", username,
       "queryCriteria", "or");
 
     UserTenantCollection collection = userTenantClient.getUserTenants(params);
-    Assertions.assertEquals(1, collection.getTotalRecords());
-    UserTenant userTenant = collection.getUserTenants().iterator().next();
-    Assertions.assertEquals(username, userTenant.getUsername());
-    Assertions.assertEquals(tenantId, userTenant.getTenantId());
+    Assertions.assertEquals(2, collection.getTotalRecords());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -30,6 +30,7 @@ class UserTenantIT extends AbstractRestTestNoData {
 
   private static final String USER_A = "user_a";
   private static final String USER_B = "user_b";
+  private static final String USER_C = "user_c";
   private static final String TENANT_X = "tenant_x";
   private static final String TENANT_Y = "tenant_y";
 
@@ -49,6 +50,10 @@ class UserTenantIT extends AbstractRestTestNoData {
     .withId(UUID.randomUUID().toString())
     .withUserId(UUID.randomUUID().toString())
     .withUsername(USER_B).withTenantId(TENANT_Y);
+  private static final UserTenant FIFTH_AFFILIATION = new UserTenant()
+    .withId(UUID.randomUUID().toString())
+    .withUserId(UUID.randomUUID().toString())
+    .withUsername(USER_C).withTenantId(TENANT_Y).withEmail("test@mail.org");
 
   @BeforeAll
   @SneakyThrows
@@ -141,18 +146,6 @@ class UserTenantIT extends AbstractRestTestNoData {
   }
 
   @Test
-  void canSearchByUserNameAndTenantIdWithOrCriteria() {
-    String username = THIRD_AFFILIATION.getUsername();
-    Map<String, String> params = Map.of(
-      "username", username,
-      "tenantId", username,
-      "queryCriteria", "or");
-
-    UserTenantCollection collection = userTenantClient.getUserTenants(params);
-    Assertions.assertEquals(1, collection.getTotalRecords());
-  }
-
-  @Test
   void canCreateAUserTenant() {
     UserTenantCollection collection = userTenantClient.getAllUsersTenants();
 
@@ -188,6 +181,26 @@ class UserTenantIT extends AbstractRestTestNoData {
     collection = userTenantClient.getAllUsersTenants();
 
     Assertions.assertEquals(3, collection.getTotalRecords());
+  }
+
+  @Test
+  void canSearchByUserNameAndEmailWithOrOperation() {
+
+    int actualStatusCode = userTenantClient.attemptToSaveUserTenant(FIFTH_AFFILIATION);
+    Assertions.assertEquals(201, actualStatusCode);
+
+    String username = FIFTH_AFFILIATION.getUsername();
+    String tenantId = FIFTH_AFFILIATION.getTenantId();
+    Map<String, String> params = Map.of(
+      "username", username,
+      "email", username,
+      "queryOp", "or");
+
+    UserTenantCollection collection = userTenantClient.getUserTenants(params);
+    Assertions.assertEquals(1, collection.getTotalRecords());
+    UserTenant userTenant = collection.getUserTenants().iterator().next();
+    Assertions.assertEquals(username, userTenant.getUsername());
+    Assertions.assertEquals(tenantId, userTenant.getTenantId());
   }
 
   private void awaitHandlingEvent(int expectedSize) {

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -180,7 +180,7 @@ class UserTenantIT extends AbstractRestTestNoData {
 
   @Test
   void canSearchByUserNameAndEmailWithOrOperation() {
-    String username = "testUser";
+    String username = "testCrossTenantUser";
     String tenantId = "testTenant";
     String email = "test@mail.org";
 

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -146,11 +146,14 @@ class UserTenantIT extends AbstractRestTestNoData {
     String tenantId = THIRD_AFFILIATION.getTenantId();
     Map<String, String> params = Map.of(
       "username", username,
-      "tenantId", tenantId,
+      "tenantId", username,
       "queryCriteria", "or");
 
     UserTenantCollection collection = userTenantClient.getUserTenants(params);
-    Assertions.assertEquals(2, collection.getTotalRecords());
+    Assertions.assertEquals(1, collection.getTotalRecords());
+    UserTenant userTenant = collection.getUserTenants().iterator().next();
+    Assertions.assertEquals(username, userTenant.getUsername());
+    Assertions.assertEquals(tenantId, userTenant.getTenantId());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -203,6 +203,10 @@ class UserTenantIT extends AbstractRestTestNoData {
     Assertions.assertEquals(username, userTenant.getUsername());
     Assertions.assertEquals(tenantId, userTenant.getTenantId());
     Assertions.assertEquals(email, userTenant.getEmail());
+
+    UserTenantCollection userTenantCollection = userTenantClient.getAllUsersTenants();
+    Assertions.assertEquals(4, userTenantCollection.getTotalRecords());
+    sendAffiliationDeletedEvents(userTenantCollection.getUserTenants());
   }
 
   private void awaitHandlingEvent(int expectedSize) {

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -207,7 +207,7 @@ class UserTenantIT extends AbstractRestTestNoData {
 
   private void awaitHandlingEvent(int expectedSize) {
     Awaitility.await()
-      .atMost(3, TimeUnit.MINUTES)
+      .atMost(1, TimeUnit.MINUTES)
       .pollInterval(5, SECONDS)
       .until(() -> {
         UserTenantCollection collection = userTenantClient.getAllUsersTenants();

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -149,7 +149,7 @@ class UserTenantIT extends AbstractRestTestNoData {
       "queryCriteria", "or");
 
     UserTenantCollection collection = userTenantClient.getUserTenants(params);
-    Assertions.assertEquals(2, collection.getTotalRecords());
+    Assertions.assertEquals(1, collection.getTotalRecords());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -30,7 +30,6 @@ class UserTenantIT extends AbstractRestTestNoData {
 
   private static final String USER_A = "user_a";
   private static final String USER_B = "user_b";
-  private static final String USER_C = "user_c";
   private static final String TENANT_X = "tenant_x";
   private static final String TENANT_Y = "tenant_y";
 
@@ -50,10 +49,6 @@ class UserTenantIT extends AbstractRestTestNoData {
     .withId(UUID.randomUUID().toString())
     .withUserId(UUID.randomUUID().toString())
     .withUsername(USER_B).withTenantId(TENANT_Y);
-  private static final UserTenant FIFTH_AFFILIATION = new UserTenant()
-    .withId(UUID.randomUUID().toString())
-    .withUserId(UUID.randomUUID().toString())
-    .withUsername(USER_C).withTenantId(TENANT_Y).withEmail("test@mail.org");
 
   @BeforeAll
   @SneakyThrows
@@ -185,12 +180,18 @@ class UserTenantIT extends AbstractRestTestNoData {
 
   @Test
   void canSearchByUserNameAndEmailWithOrOperation() {
+    String username = "testUser";
+    String tenantId = "testTenant";
+    String email = "test@mail.org";
 
-    int actualStatusCode = userTenantClient.attemptToSaveUserTenant(FIFTH_AFFILIATION);
+    UserTenant affiliation = new UserTenant()
+      .withId(UUID.randomUUID().toString())
+      .withUserId(UUID.randomUUID().toString())
+      .withUsername(username).withTenantId(tenantId).withEmail(email);
+
+    int actualStatusCode = userTenantClient.attemptToSaveUserTenant(affiliation);
     Assertions.assertEquals(201, actualStatusCode);
 
-    String username = FIFTH_AFFILIATION.getUsername();
-    String tenantId = FIFTH_AFFILIATION.getTenantId();
     Map<String, String> params = Map.of(
       "username", username,
       "email", username,
@@ -201,11 +202,12 @@ class UserTenantIT extends AbstractRestTestNoData {
     UserTenant userTenant = collection.getUserTenants().iterator().next();
     Assertions.assertEquals(username, userTenant.getUsername());
     Assertions.assertEquals(tenantId, userTenant.getTenantId());
+    Assertions.assertEquals(email, userTenant.getEmail());
   }
 
   private void awaitHandlingEvent(int expectedSize) {
     Awaitility.await()
-      .atMost(1, TimeUnit.MINUTES)
+      .atMost(3, TimeUnit.MINUTES)
       .pollInterval(5, SECONDS)
       .until(() -> {
         UserTenantCollection collection = userTenantClient.getAllUsersTenants();


### PR DESCRIPTION
[MODUSERBL-169](https://issues.folio.org/browse/MODUSERBL-169)
Before this change /user-tenant endpoint filters by username, userId, ematil etc only using AND operator.
For Forgot password/Forgot username we need to search by mutiple fields using OR operator and we introduced new param to specify operator for filtering. AND is by default