### PR TITLE
[MODUSERS-376] - "Username" field on "Log in" page is case-sensitive for "member" user on "Consortia" environment

### DIFF
--- a/src/main/java/org/folio/repository/UserTenantRepository.java
+++ b/src/main/java/org/folio/repository/UserTenantRepository.java
@@ -24,6 +24,7 @@ public class UserTenantRepository {
   public static final String USERNAME_FIELD = "username";
   public static final String TENANT_ID_FIELD = "tenant_id";
   public static final String CENTRAL_TENANT_ID = "central_tenant_id";
+  public static final String LOWERCASE_WRAPPED_USERNAME = String.format("LOWER(%s)", USERNAME_FIELD);
   public static final String PHONE_NUMBER = "phone_number";
   public static final String MOBILE_PHONE_NUMBER = "mobile_phone_number";
   public static final String EMAIL = "email";

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -78,7 +78,7 @@ public class UserTenantsAPI implements UserTenants {
   private void addWhereClauseArgumentsToCriterion(ArgumentsHolder argumentsHolder, String queryOp, Criterion criterion) {
     Map<String, String> fields = Map.of(
       USER_ID_FIELD, StringUtils.defaultString(argumentsHolder.userId()),
-      USERNAME_FIELD, StringUtils.defaultString(argumentsHolder.username()),
+      USERNAME_FIELD, StringUtils.defaultString(argumentsHolder.username().toLowerCase()),
       TENANT_ID_FIELD, StringUtils.defaultString(argumentsHolder.tenantId()),
       EMAIL, StringUtils.defaultString(argumentsHolder.email()),
       PHONE_NUMBER, StringUtils.defaultString(argumentsHolder.phoneNumber()),

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -23,7 +23,7 @@ import static org.folio.repository.UserTenantRepository.EMAIL;
 import static org.folio.repository.UserTenantRepository.MOBILE_PHONE_NUMBER;
 import static org.folio.repository.UserTenantRepository.PHONE_NUMBER;
 import static org.folio.repository.UserTenantRepository.TENANT_ID_FIELD;
-import static org.folio.repository.UserTenantRepository.USERNAME_FIELD;
+import static org.folio.repository.UserTenantRepository.LOWERCASE_WRAPPED_USERNAME;
 import static org.folio.repository.UserTenantRepository.USER_ID_FIELD;
 
 public class UserTenantsAPI implements UserTenants {
@@ -78,7 +78,7 @@ public class UserTenantsAPI implements UserTenants {
   private void addWhereClauseArgumentsToCriterion(ArgumentsHolder argumentsHolder, String queryOp, Criterion criterion) {
     Map<String, String> fields = Map.of(
       USER_ID_FIELD, StringUtils.defaultString(argumentsHolder.userId()),
-      USERNAME_FIELD, StringUtils.defaultString(argumentsHolder.username().toLowerCase()),
+      LOWERCASE_WRAPPED_USERNAME, StringUtils.defaultString(argumentsHolder.username().toLowerCase()),
       TENANT_ID_FIELD, StringUtils.defaultString(argumentsHolder.tenantId()),
       EMAIL, StringUtils.defaultString(argumentsHolder.email()),
       PHONE_NUMBER, StringUtils.defaultString(argumentsHolder.phoneNumber()),

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -78,7 +78,7 @@ public class UserTenantsAPI implements UserTenants {
   private void addWhereClauseArgumentsToCriterion(ArgumentsHolder argumentsHolder, String queryOp, Criterion criterion) {
     Map<String, String> fields = Map.of(
       USER_ID_FIELD, StringUtils.defaultString(argumentsHolder.userId()),
-      LOWERCASE_WRAPPED_USERNAME, StringUtils.defaultString(argumentsHolder.username().toLowerCase()),
+      LOWERCASE_WRAPPED_USERNAME, StringUtils.defaultString(StringUtils.toRootLowerCase(argumentsHolder.username())),
       TENANT_ID_FIELD, StringUtils.defaultString(argumentsHolder.tenantId()),
       EMAIL, StringUtils.defaultString(argumentsHolder.email()),
       PHONE_NUMBER, StringUtils.defaultString(argumentsHolder.phoneNumber()),

--- a/src/main/resources/templates/db_scripts/create_user_tenants_table.sql
+++ b/src/main/resources/templates/db_scripts/create_user_tenants_table.sql
@@ -6,4 +6,5 @@ CREATE TABLE IF NOT EXISTS user_tenant (
   creation_date timestamp without time zone
 );
 
-CREATE INDEX IF NOT EXISTS username_idx ON user_tenant USING BTREE (username);
+DROP INDEX IF EXISTS ${myuniversity}_${mymodule}.username_idx;
+CREATE INDEX IF NOT EXISTS username_idx ON user_tenant USING BTREE (LOWER(f_unaccent(username));

--- a/src/main/resources/templates/db_scripts/create_user_tenants_table.sql
+++ b/src/main/resources/templates/db_scripts/create_user_tenants_table.sql
@@ -6,5 +6,4 @@ CREATE TABLE IF NOT EXISTS user_tenant (
   creation_date timestamp without time zone
 );
 
-DROP INDEX IF EXISTS ${myuniversity}_${mymodule}.username_idx;
-CREATE INDEX IF NOT EXISTS username_idx ON user_tenant USING BTREE (LOWER(f_unaccent(username));
+CREATE INDEX IF NOT EXISTS username_idx ON user_tenant USING BTREE (username);

--- a/src/main/resources/templates/db_scripts/update_user_tenants_table.sql
+++ b/src/main/resources/templates/db_scripts/update_user_tenants_table.sql
@@ -3,3 +3,6 @@ ALTER TABLE user_tenant
   ADD COLUMN IF NOT EXISTS email text,
   ADD COLUMN IF NOT EXISTS mobile_phone_number text,
   ADD COLUMN IF NOT EXISTS phone_number text;
+
+DROP INDEX IF EXISTS ${myuniversity}_${mymodule}.username_idx;
+CREATE INDEX IF NOT EXISTS username_idx ON user_tenant USING BTREE (LOWER(f_unaccent(username)));

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -209,6 +209,35 @@ class UserTenantIT extends AbstractRestTestNoData {
     sendAffiliationDeletedEvents(userTenantCollection.getUserTenants());
   }
 
+  @Test
+  void canSearchByUserNameCaseInsensitive() {
+    String username = "CaSe-InSeNsItIvE";
+    String lowerCaseUsername = "case-insensitive";
+    String tenantId = "testTenant";
+    String email = "test@mail.org";
+
+    UserTenant affiliation = new UserTenant()
+      .withId(UUID.randomUUID().toString())
+      .withUserId(UUID.randomUUID().toString())
+      .withUsername(username).withTenantId(tenantId).withEmail(email);
+
+    int actualStatusCode = userTenantClient.attemptToSaveUserTenant(affiliation);
+    Assertions.assertEquals(201, actualStatusCode);
+
+    Map<String, String> params = Map.of("username", lowerCaseUsername);
+
+    UserTenantCollection collection = userTenantClient.getUserTenants(params);
+    Assertions.assertEquals(1, collection.getTotalRecords());
+    UserTenant userTenant = collection.getUserTenants().iterator().next();
+    Assertions.assertEquals(username, userTenant.getUsername());
+    Assertions.assertEquals(tenantId, userTenant.getTenantId());
+    Assertions.assertEquals(email, userTenant.getEmail());
+
+    UserTenantCollection userTenantCollection = userTenantClient.getAllUsersTenants();
+    Assertions.assertEquals(4, userTenantCollection.getTotalRecords());
+    sendAffiliationDeletedEvents(userTenantCollection.getUserTenants());
+  }
+
   private void awaitHandlingEvent(int expectedSize) {
     Awaitility.await()
       .atMost(1, TimeUnit.MINUTES)


### PR DESCRIPTION
## Purpose
Fix case sensitivity issue with the "username" field on the "Log in" page for "member" users in the "Consortia" environment. Ensure successful login regardless of username letter case.

## Approach
- Index for username column was updated.  Indexing is now functional using the LOWER PG function.
- Username field will be compared only in lower case when fetching user-tenants.

## Learning
[MODUSERS-376](https://issues.folio.org/browse/MODUSERS-376)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [x] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [x] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.