### PR TITLE
Use correct snapshot version for next release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-users</artifactId>
-  <version>19.2.1-SNAPSHOT</version>
+  <version>19.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>


### PR DESCRIPTION
## Purpose
Platform complete version for mod-users contains already released version
https://github.com/folio-org/platform-complete/blob/snapshot/install.json#L101 19.2.1 that ovverides the latest snapshot version.
The latest snapshot version always should contain higher version that latest release version