### PR TITLE
MODUSERS-408. ECS | Username uniqueness validation should be case insensitive

### DIFF
--- a/src/main/java/org/folio/repository/UserTenantRepository.java
+++ b/src/main/java/org/folio/repository/UserTenantRepository.java
@@ -60,7 +60,7 @@ public class UserTenantRepository {
 
   public Future<Boolean> isUsernameAlreadyExists(Conn conn, String username, String tenantId) {
     String query = String.format(IS_USERNAME_ALREADY_EXISTS, convertToPsqlStandard(tenantId), USER_TENANT_TABLE_NAME);
-    Tuple queryParams = Tuple.of(username);
+    Tuple queryParams = Tuple.of(StringUtils.toRootLowerCase(username));
     return conn.execute(query, queryParams).map(resultSet -> resultSet.iterator().next().getBoolean(0));
   }
 

--- a/src/test/java/org/folio/rest/impl/UsersAPIConsortiaTest.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIConsortiaTest.java
@@ -225,6 +225,18 @@ class UsersAPIConsortiaTest extends AbstractRestTestNoData {
   }
 
   @Test
+  void cannotCreateUserWithSameUsernameInUpperCase() {
+    UserTenant userTenant = getUserTenant();
+    userTenantClient.attemptToSaveUserTenant(userTenant);
+    String userId = UUID.randomUUID().toString();
+    String usernameInUpperCase = "User_Test";
+    final User userToCreate = createUser(userId, usernameInUpperCase, "julia", "staff");
+    usersClient.attemptToCreateUser(userToCreate)
+      .statusCode(422)
+      .extract().as(ValidationErrors.class);
+  }
+
+  @Test
   void cannotCreateUserWithoutUserTypeForConsortia() {
     UserTenant userTenant = getUserTenant();
     userTenantClient.attemptToSaveUserTenant(userTenant);


### PR DESCRIPTION
## Purpose
Make call to user-tenant table to check if username exists case insensitive
https://issues.folio.org/browse/MODUSERS-408