### PR TITLE
[FCFIELDS-44] Update to latest `folio-custom-fields`

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -148,7 +148,7 @@
     },
     {
       "id": "custom-fields",
-      "version": "2.1",
+      "version": "3.0",
       "interfaceType" : "multiple",
       "handlers": [
         {

--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.8.1</junit.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
-    <folio-custom-fields.version>1.10.0</folio-custom-fields.version>
+    <folio-custom-fields.version>2.0.0-SNAPSHOT</folio-custom-fields.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <java.version>17</java.version>
     <aspectj.version>1.9.19</aspectj.version>


### PR DESCRIPTION
## Purpose
This PR aims to update the `folio-custom-fields` dependency to its latest snapshot version and the provided `custom-fields` interface to version `3.0`. Its related to [FCFIELDS-44](https://issues.folio.org/browse/FCFIELDS-44).

Upcoming modifications in the custom fields UI components that are used by `ui-users` necessitate this update (see [STSMACOM PR#1417](https://github.com/folio-org/stripes-smart-components/pull/1417)). Once these modifications are merged, the UI components will require `custom-fields 3.0` to function correctly.

## Additional Actions
- This PR needs to be merged together with [STSMACOM PR#1417](https://github.com/folio-org/stripes-smart-components/pull/1417).
