### PR TITLE
[MODUSERS-426] Add migration script for custom fields

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -3,7 +3,12 @@
     {
       "run": "after",
       "snippetPath": "create_custom_fields_table.sql",
-      "fromModuleVersion": "mod-users-15.7.0"
+      "fromModuleVersion": "19.3.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "custom_fields_metadata_cleanup.sql",
+      "fromModuleVersion": "19.3.0"
     },
     {
       "run": "after",


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODUSERS-426

A database trigger for `custom_fields` table was updated to not set any metadata values to `"undefined"` (see [FCFIELDS-47](https://issues.folio.org/browse/FCFIELDS-47) and [PR#44](https://github.com/folio-org/folio-custom-fields/pull/44)). To ensure no such values are present after module upgrade the provided migration script needs to run.

## Approach
Updated `schema.json`.
