### PR TITLE
MODUSERS-446: Remove aws-java-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.12.321</version>
-    </dependency>
-    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-s3-client</artifactId>
       <version>${folio-s3-client.version}</version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUSERS-446

mod-users has the com.amazonaws:aws-java-sdk dependency.

This dependency is not needed.

This dependency increases the size of mod-users-fat.jar from 67 MB to 351 MB.

Solution: Removing the dependency.