### PR TITLE
[MODUSERS-451] Consume and handle patron update domain events

### DIFF
--- a/src/main/java/org/folio/repository/UserRepository.java
+++ b/src/main/java/org/folio/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package org.folio.repository;
+
+import static org.folio.rest.persist.PgUtil.postgresClient;
+
+import java.util.Map;
+
+import org.folio.rest.jaxrs.model.User;
+
+import io.vertx.core.Context;
+
+public class UserRepository extends AbstractRepository<User> {
+  public static final String USER_TABLE = "users";
+
+  public UserRepository(Context context, Map<String, String> okapiHeaders) {
+    super(postgresClient(context, okapiHeaders), USER_TABLE, User.class);
+  }
+}

--- a/src/main/java/org/folio/service/UsersService.java
+++ b/src/main/java/org/folio/service/UsersService.java
@@ -1,37 +1,51 @@
 package org.folio.service;
 
-import io.vertx.core.Future;
-import io.vertx.ext.web.handler.HttpException;
+import static org.folio.service.event.EntityChangedEventPublisherFactory.userEventPublisher;
+import static org.folio.support.UsersApiConstants.TABLE_NAME_USERS;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.Personal;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.persist.Conn;
+import org.folio.service.event.EntityChangedEventPublisher;
 
-import javax.ws.rs.core.Response;
-
-import static org.folio.support.UsersApiConstants.TABLE_NAME_USERS;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.ext.web.handler.HttpException;
 
 public class UsersService {
 
   private static final Logger logger = LogManager.getLogger(UsersService.class);
+  private final EntityChangedEventPublisher<String, User> eventPublisher;
+
+  public UsersService(Context vertxContext, Map<String, String> okapiHeaders) {
+    this.eventPublisher = userEventPublisher(vertxContext, okapiHeaders);
+  }
 
   public Future<User> getUserByIdForUpdate(Conn conn, String userId) {
     return conn.getByIdForUpdate(TABLE_NAME_USERS, userId, User.class)
       .onFailure(t -> logger.error("getUserByIdForUpdate failed, userId={}", userId, t));
   }
 
-  public Future<User> updateUser(Conn conn, User user) {
-    return conn.update(TABLE_NAME_USERS, user, user.getId())
+  public Future<User> updateUser(Conn conn, User oldEntity, User newEntity) {
+
+    return conn.update(TABLE_NAME_USERS, newEntity, newEntity.getId())
       .compose(rowSet -> {
         if (rowSet.rowCount() == 0) {
-          String errorMsg = String.format("User with id %s was not found", user.getId());
+          String errorMsg = String.format("User with id %s was not found", newEntity.getId());
           return Future.failedFuture(new HttpException(Response.Status.NOT_FOUND.getStatusCode(), errorMsg));
         }
-        return Future.succeededFuture(user);
+        eventPublisher.publishUpdated(eventPublisher.getKeyExtractor().apply(oldEntity),
+          oldEntity, newEntity);
+        return Future.succeededFuture(newEntity);
       })
-      .onSuccess(x -> logger.info("updateUser complete, userId={}", user.getId()))
-      .onFailure(e -> logger.error("updateUser failed, userId={}", user.getId(), e));
+      .onSuccess(x -> logger.info("updateUser complete, userId={}", newEntity.getId()))
+      .onFailure(e -> logger.error("updateUser failed, userId={}", newEntity.getId(), e));
   }
 
   public static User getConsortiumUserDto(User user) {

--- a/src/main/java/org/folio/service/event/EntityChangedEventPublisher.java
+++ b/src/main/java/org/folio/service/event/EntityChangedEventPublisher.java
@@ -28,9 +28,9 @@ public class EntityChangedEventPublisher<K, T> {
   private final AbstractRepository<T> repository;
 
   EntityChangedEventPublisher(Map<String, String> okapiHeaders,
-    Function<T, K> keyExtractor, EntityChangedEventFactory<T> eventFactory,
-    DomainEventPublisher<K, EntityChangedData<T>> eventPublisher,
-    AbstractRepository<T> repository) {
+                              Function<T, K> keyExtractor, EntityChangedEventFactory<T> eventFactory,
+                              DomainEventPublisher<K, EntityChangedData<T>> eventPublisher,
+                              AbstractRepository<T> repository) {
 
     this.okapiHeaders = okapiHeaders;
     this.keyExtractor = keyExtractor;
@@ -56,6 +56,7 @@ public class EntityChangedEventPublisher<K, T> {
 
   public Function<Response, Future<Response>> publishUpdated(T oldEntity) {
     return response -> {
+      log.info("publishUpdated:: response = {}", response);
       if (!isUpdateSuccessResponse(response)) {
         log.warn("publishUpdated:: record update failed, skipping event publishing");
         return succeededFuture(response);
@@ -63,8 +64,8 @@ public class EntityChangedEventPublisher<K, T> {
 
       K key = keyExtractor.apply(oldEntity);
       return repository.getById(key.toString())
-          .compose(newEntity -> publishUpdated(key, oldEntity, newEntity))
-          .map(response);
+        .compose(newEntity -> publishUpdated(key, oldEntity, newEntity))
+        .map(response);
     };
   }
 
@@ -76,7 +77,7 @@ public class EntityChangedEventPublisher<K, T> {
       }
 
       return publishRemoved(keyExtractor.apply(oldEntity), oldEntity)
-          .map(response);
+        .map(response);
     };
   }
 
@@ -106,5 +107,9 @@ public class EntityChangedEventPublisher<K, T> {
 
   private boolean responseHasStatus(Response response, HttpStatus expectedStatus) {
     return response != null && response.getStatus() == expectedStatus.toInt();
+  }
+
+  public Function<T, K> getKeyExtractor() {
+    return keyExtractor;
   }
 }

--- a/src/main/java/org/folio/service/event/EntityChangedEventPublisherFactory.java
+++ b/src/main/java/org/folio/service/event/EntityChangedEventPublisherFactory.java
@@ -2,10 +2,13 @@ package org.folio.service.event;
 
 import static org.folio.rest.tools.utils.TenantTool.tenantId;
 import static org.folio.support.kafka.topic.UsersKafkaTopic.USER_GROUP;
+import static org.folio.support.kafka.topic.UsersKafkaTopic.USER_UPDATED;
 
 import java.util.Map;
 
 import org.folio.repository.UserGroupRepository;
+import org.folio.repository.UserRepository;
+import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.jaxrs.model.Usergroup;
 
 import io.vertx.core.Context;
@@ -18,11 +21,20 @@ public class EntityChangedEventPublisherFactory {
   }
 
   public static EntityChangedEventPublisher<String, Usergroup> userGroupEventPublisher(
-      Context vertxContext, Map<String, String> okapiHeaders) {
+    Context vertxContext, Map<String, String> okapiHeaders) {
 
     return new EntityChangedEventPublisher<>(okapiHeaders, Usergroup::getId,
       new EntityChangedEventFactory<>(), new DomainEventPublisher<>(vertxContext,
       USER_GROUP.fullTopicName(tenantId(okapiHeaders)), FailureHandler.noOperation()),
       new UserGroupRepository(vertxContext, okapiHeaders));
+  }
+
+  public static EntityChangedEventPublisher<String, User> userEventPublisher(
+    Context vertxContext, Map<String, String> okapiHeaders) {
+
+    return new EntityChangedEventPublisher<>(okapiHeaders, User::getId,
+      new EntityChangedEventFactory<>(), new DomainEventPublisher<>(vertxContext,
+      USER_UPDATED.fullTopicName(tenantId(okapiHeaders)), FailureHandler.noOperation()),
+      new UserRepository(vertxContext, okapiHeaders));
   }
 }

--- a/src/main/java/org/folio/support/kafka/topic/UsersKafkaTopic.java
+++ b/src/main/java/org/folio/support/kafka/topic/UsersKafkaTopic.java
@@ -3,7 +3,8 @@ package org.folio.support.kafka.topic;
 import org.folio.kafka.services.KafkaTopic;
 
 public enum UsersKafkaTopic implements KafkaTopic {
-  USER_GROUP("userGroup", 10);
+  USER_GROUP("userGroup", 10), USER_UPDATED("userUpdated", 10);
+
   private final String topic;
   private final int partitions;
 

--- a/src/main/java/org/folio/verticle/ConsortiumUpdateEventConsumersVerticle.java
+++ b/src/main/java/org/folio/verticle/ConsortiumUpdateEventConsumersVerticle.java
@@ -1,6 +1,7 @@
 package org.folio.verticle;
 
 import org.folio.kafka.AsyncRecordHandler;
+import org.folio.support.kafka.topic.UsersKafkaTopic;
 import org.folio.verticle.consumers.ConsortiumUpdateEventsHandler;
 
 import java.util.List;
@@ -10,7 +11,8 @@ import static org.folio.event.ConsortiumEventType.CONSORTIUM_PRIMARY_AFFILIATION
 public class ConsortiumUpdateEventConsumersVerticle extends AbstractConsumersVerticle {
 
   public List<String> getEvents() {
-    return List.of(CONSORTIUM_PRIMARY_AFFILIATION_UPDATED.getTopicName());
+    return List.of(CONSORTIUM_PRIMARY_AFFILIATION_UPDATED.getTopicName(),
+      UsersKafkaTopic.USER_UPDATED.topicName());
   }
 
   public AsyncRecordHandler<String, String> getHandler() {

--- a/src/main/java/org/folio/verticle/consumers/ConsortiumCreateEventsHandler.java
+++ b/src/main/java/org/folio/verticle/consumers/ConsortiumCreateEventsHandler.java
@@ -31,6 +31,7 @@ public class ConsortiumCreateEventsHandler implements AsyncRecordHandler<String,
 
   @Override
   public Future<String> handle(KafkaConsumerRecord<String, String> record) {
+    logger.info("User create event received: {}", record.value());
     Promise<String> result = Promise.promise();
     List<KafkaHeader> kafkaHeaders = record.headers();
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);

--- a/src/main/java/org/folio/verticle/consumers/ConsortiumUpdateEventsHandler.java
+++ b/src/main/java/org/folio/verticle/consumers/ConsortiumUpdateEventsHandler.java
@@ -31,6 +31,7 @@ public class ConsortiumUpdateEventsHandler implements AsyncRecordHandler<String,
   public Future<String> handle(KafkaConsumerRecord<String, String> record) {
     List<KafkaHeader> kafkaHeaders = record.headers();
     OkapiConnectionParams okapiConnectionParams = new OkapiConnectionParams(KafkaHeaderUtils.kafkaHeadersToMap(kafkaHeaders), vertx);
+    logger.info("User update event received: {}", record.value());
     UserTenant event = new JsonObject(record.value()).mapTo(UserTenant.class);
     logger.info("Trying to update of user primary affiliation with event id: {} for user id: {} with tenant id: {}",
       event.getId(), event.getUserId(), event.getTenantId());


### PR DESCRIPTION
Covers: [MODUSERS-451](https://folio-org.atlassian.net/browse/MODUSERS-451)

## Purpose
mod-users needs to be able to synchronize patron updates between tenants in a multi-tenant ECS environment.