### PR TITLE
MODUSERS-480: Remove orderBy and order params from GET /users API

### DIFF
--- a/ramls/users.raml
+++ b/ramls/users.raml
@@ -17,7 +17,6 @@ types:
   errors: !include raml-util/schemas/errors.schema
 
 traits:
-  orderable: !include raml-util/traits/orderable.raml
   pageable: !include raml-util/traits/pageable.raml
   searchable: !include raml-util/traits/searchable.raml
   validate: !include raml-util/traits/validation.raml
@@ -38,7 +37,6 @@ resourceTypes:
   get:
     is: [
       searchable: {description: "", example: "active=true sortBy username"},
-      orderable: {fieldsList: "field A, field B"},
       pageable
     ]
     description: Return a list of users

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -84,7 +84,6 @@ import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.jaxrs.model.UserEvent;
-import org.folio.rest.jaxrs.model.UsersGetOrder;
 import org.folio.rest.jaxrs.resource.Users;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
@@ -195,7 +194,7 @@ public class UsersAPI implements Users {
 
   @Validate
   @Override
-  public void getUsers(String query, String orderBy, UsersGetOrder order, String totalRecords, int offset, int limit,
+  public void getUsers(String query, String totalRecords, int offset, int limit,
     RoutingContext routingContext, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     try {

--- a/src/test/java/org/folio/rest/impl/UsersAPITest.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPITest.java
@@ -84,7 +84,7 @@ class UsersAPITest {
 
   @Test
   void getUsersExceptionInCatch(VertxTestContext vtc) {
-    new UsersAPI().getUsers(null, null, null, null, 0, 0, null, null,
+    new UsersAPI().getUsers(null, null, 0, 0, null, null,
         vtc.succeeding(response -> vtc.verify( () -> {
           assertThat(response.getStatus(), is(500));
           vtc.completeNow();


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUSERS-480

The orderable parameters (orderBy and order) of the GET /users API are not used. Removing them is not a breaking change because they can still be passed and they still get ignored.

## Purpose
Unimplemented parameters are misleading for readers of the API documentation.

## Approach
Remove orderable parameters (orderBy and order).
This is a pure documentation change. The implementation stays the same.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.