### PR TITLE
MODUSERS-479 Convert the keywords search into extensive search as the view doesn't support keyword search

### DIFF
--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -156,14 +156,30 @@ public class UsersAPI implements Users {
    * @return
    */
   private static String convertQuery(String cql){
-    cql = getKeywordSearchString(cql);
+    cql = convertKeywordSearchToExtensiveSearch(cql);
     if (cql != null) {
       return cql.replaceAll("(?i)patronGroup\\.", VIEW_NAME_USER_GROUPS_JOIN+".group_jsonb.");
     }
     return cql;
   }
 
-  private static String getKeywordSearchString(String cql) {
+  /**
+   * Converts a CQL query containing a keyword search to an extensive field-based search.
+   * <p>
+   * If the provided CQL query contains a keyword search in the format <code>keywords="searchString"</code>,
+   * this method extracts the search string using a regex and replaces it with an OR-based search across multiple fields
+   * such as <code>username</code>, <code>personal.firstName</code>, <code>personal.preferredFirstName</code>, etc.
+   * This transformation is necessary because the <code>user_groups_view</code> does not support keyword-based searches
+   * and instead requires field-specific queries.
+   * </p>
+   * <p>
+   * If no keyword search is detected, the original CQL query is returned unchanged.
+   * </p>
+   *
+   * @param cql the original CQL query string
+   * @return the updated CQL query with extensive field-based search if keywords are present, otherwise the original query
+   */
+  private static String convertKeywordSearchToExtensiveSearch(String cql) {
     if (cql != null) {
       Pattern pattern = Pattern.compile("keywords=\"([^\"]*)\"");
       Matcher matcher = pattern.matcher(cql);

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -615,6 +615,10 @@ class UsersAPIIT extends AbstractRestTestNoData {
     // passing the patrongroup filter in cql query, this will look the user details in the user_group_view
     response = usersClient.getUsers("((keywords=\"user*\") and active==\"true\") sortby patronGroup.group personal.lastName personal.firstName");
     assertThat(response.getTotalRecords(), is(2));
+
+    // passing the patrongroup filter without keywords based search in cql query, this will look the user details in the user_group_view
+    response = usersClient.getUsers("(active==\"true\") sortby patronGroup.group personal.lastName personal.firstName");
+    assertThat(response.getTotalRecords(), is(2));
   }
   @Test
   void canDeleteAUser() {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
The purpose of the PR is to fix MODUSERS-479
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODQM-3
 -->

## Approach
Recently, we introduced a keywords index that combines multiple fields to enable keyword-based searches. The front end utilizes this index with queries like:
`keywords="a*" sortby personal.lastName personal.firstName
`

However, this approach does not work when sorting by patron group. If the CQL query contains patronGroup., it queries the user_groups_view, which does not support keyword-based searches. As a result, the response returns 0 records.

To address this limitation, whenever a keywords search is combined with patronGroup. in the CQL query, we convert the keywords search into an extensive fields-based search (similar to the approach the front end used previously). This ensures that the search yields the expected results even when sorting by patron group.

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
