### PR TITLE
MODUSERS-486 - Sorting users by patron group with applied filters changes number of found records

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -68,7 +68,7 @@
     {
       "run": "after",
       "snippetPath": "update_users_groups_view.sql",
-      "fromModuleVersion": "19.3.0"
+      "fromModuleVersion": "19.4.0"
     },
     {
       "run": "before",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -68,7 +68,7 @@
     {
       "run": "after",
       "snippetPath": "update_users_groups_view.sql",
-      "fromModuleVersion": "19.4.0"
+      "fromModuleVersion": "19.4.1"
     },
     {
       "run": "before",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -66,6 +66,11 @@
       "fromModuleVersion": "19.3.0"
     },
     {
+      "run": "after",
+      "snippetPath": "update_users_groups_view.sql",
+      "fromModuleVersion": "19.3.0"
+    },
+    {
       "run": "before",
       "snippet": "DO $$ BEGIN DROP TABLE patron_block_conditions, patron_block_limits; EXCEPTION WHEN OTHERS THEN END; $$;",
       "fromModuleVersion": "mod-users-16.2.1"

--- a/src/main/resources/templates/db_scripts/update_users_groups_view.sql
+++ b/src/main/resources/templates/db_scripts/update_users_groups_view.sql
@@ -1,7 +1,11 @@
-ALTER VIEW users_groups_view AS
-SELECT users.id,
-       users.jsonb,
-       groups.jsonb AS group_jsonb
-  FROM users
-       LEFT JOIN groups
-       ON users.f_unaccent(users.jsonb ->> 'patronGroup'::text) = (groups.jsonb ->> 'id'::text);
+CREATE OR REPLACE VIEW ${myuniversity}_${mymodule}.users_groups_view AS
+SELECT
+    u.id,
+    u.jsonb,
+    g.jsonb AS group_jsonb
+FROM
+    ${myuniversity}_${mymodule}.users u
+LEFT JOIN
+    ${myuniversity}_${mymodule}.groups g
+ON
+    ${myuniversity}_${mymodule}.f_unaccent(u.jsonb ->> 'patronGroup') = (g.jsonb ->> 'id');

--- a/src/main/resources/templates/db_scripts/update_users_groups_view.sql
+++ b/src/main/resources/templates/db_scripts/update_users_groups_view.sql
@@ -1,0 +1,7 @@
+ALTER VIEW users_groups_view AS
+SELECT users.id,
+       users.jsonb,
+       groups.jsonb AS group_jsonb
+  FROM users
+       LEFT JOIN groups
+       ON users.f_unaccent(users.jsonb ->> 'patronGroup'::text) = (groups.jsonb ->> 'id'::text);

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -569,11 +569,13 @@ class UsersAPIIT extends AbstractRestTestNoData {
         .username("stephanie").patronGroup(student.getId()).build());
     usersClient.createUser(User.builder()
         .username("steve").patronGroup(staff.getId()).build());
+    usersClient.createUser(User.builder()
+      .username("steven").patronGroup(null).build());
 
     final var cql = "keywords=\"ste*\" sortBy patronGroup.group username";
     final var foundUsers = usersClient.getUsers(cql);
 
-    assertThat(foundUsers.getUsers().size(), is(2));
+    assertThat(foundUsers.getUsers().size(), is(3));
     // should sort by patronGroup name. The two records have patronGroup id
     // and username that sort in opposite order of patronGroup name.
     assertThat(foundUsers.getUsers().get(0).getUsername(), is("steve"));


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODQM-3
 -->

The problem arises when sorting is implemented on the PatronGroup column subsequent to applying the filter Active = true. Both the filter query (Active = true) and the sorting operation on PatronGroup seem to be interacting problematically. The filter queries the user table, whereas sorting on PatronGroup accesses the users_groups_view. Notably, some user records do not appear in the users_groups_view. This issue occurs because, as observed in the snapshot, the userGroup for some users' patron groups is not set, hence those records are missing from the users_groups_view, resulting in a reduced result set.

## Approach
Made changes in the users_groups_view to use left join instead of an inner join between users and groups table to have users with/without patronGroup 
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
