### PR TITLE
Add description for totalRecords in raml/*.json

### DIFF
--- a/ramls/addresstypeCollection.json
+++ b/ramls/addresstypeCollection.json
@@ -13,7 +13,8 @@
       }
     },
     "totalRecords": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Estimated or exact total number of records, see https://github.com/folio-org/raml-module-builder#estimated-totalrecords for details"
     }
   },
   "required": [

--- a/ramls/departmentCollection.json
+++ b/ramls/departmentCollection.json
@@ -15,7 +15,8 @@
       }
     },
     "totalRecords": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Estimated or exact total number of records, see https://github.com/folio-org/raml-module-builder#estimated-totalrecords for details"
     }
   },
   "required": ["departments", "totalRecords"]

--- a/ramls/proxyforCollection.json
+++ b/ramls/proxyforCollection.json
@@ -13,7 +13,8 @@
       }
     },
     "totalRecords": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Estimated or exact total number of records, see https://github.com/folio-org/raml-module-builder#estimated-totalrecords for details"
     }
   },
   "required": [

--- a/ramls/staging_userdataCollection.json
+++ b/ramls/staging_userdataCollection.json
@@ -13,7 +13,8 @@
       }
     },
     "totalRecords": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Estimated or exact total number of records, see https://github.com/folio-org/raml-module-builder#estimated-totalrecords for details"
     },
     "resultInfo": {
       "$ref": "raml-util/schemas/resultInfo.schema",

--- a/ramls/userTenantCollection.json
+++ b/ramls/userTenantCollection.json
@@ -13,7 +13,8 @@
       }
     },
     "totalRecords": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Estimated or exact total number of records, see https://github.com/folio-org/raml-module-builder#estimated-totalrecords for details"
     }
   },
   "required": [

--- a/ramls/userdataCollection.json
+++ b/ramls/userdataCollection.json
@@ -13,7 +13,8 @@
       }
     },
     "totalRecords": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Estimated or exact total number of records, see https://github.com/folio-org/raml-module-builder#estimated-totalrecords for details"
     },
     "resultInfo": {
       "$ref": "raml-util/schemas/resultInfo.schema",

--- a/ramls/usergroups.json
+++ b/ramls/usergroups.json
@@ -13,7 +13,8 @@
       }
     },
     "totalRecords": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Estimated or exact total number of records, see https://github.com/folio-org/raml-module-builder#estimated-totalrecords for details"
     }
   }
 }


### PR DESCRIPTION
## Purpose
totalRecords is not documented on https://dev.folio.org/reference/api/#mod-users

## Approach
Add "description" for each totalRecords entry in raml/*.json

#### TODOS and Open Questions
- [x] Check logging

## Learning
Always fully document APIs:
https://dev.folio.org/guides/describe-schema/

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.