### PR TITLE
Upgrade localstack from 0.11.3 to s3-latest

### DIFF
--- a/src/test/java/org/folio/moduserstest/AbstractRestTest.java
+++ b/src/test/java/org/folio/moduserstest/AbstractRestTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractRestTest {
 
   @Container
   private static final LocalStackContainer localStackContainer = new LocalStackContainer(
-    DockerImageName.parse("localstack/localstack:0.11.3")
+    DockerImageName.parse("localstack/localstack:s3-latest")
   )
     .withServices(LocalStackContainer.Service.S3);
 


### PR DESCRIPTION
## Purpose
localstack 0.11.3 has been released June 2020 and is outdated.
It is large.

## Approach
Upgrade to s3-latest that is recent and much smaller.

#### TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.