### PR TITLE
MODUSERS-507. Staff User created in member tenant becomes as Shadow after updating email, firstname

### DIFF
--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -933,6 +933,7 @@ public class UsersAPI implements Users {
             .onSuccess(user -> {
               if (StringUtils.equals(UserType.SHADOW.getTypeName(), user.getType())) {
                 logger.info("Skip sending Update domain event for shadow user with id: {}", user.getId());
+                return;
               }
               userEventPublisher(vertxContext, okapiHeaders).publishUpdated(entity.getId(), userFromStorage, user);
             })


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODUSERS-507

- Shadow users are copies of real staff users, skip sending update events for them

- Remove user info from logs

- Close kafka producers to avoid memory leaks