### PR TITLE
[MODCONSKC-69] Add support for deleting related module's data for consortia tenant hard delete

### DIFF
--- a/ramls/userTenants.raml
+++ b/ramls/userTenants.raml
@@ -102,6 +102,12 @@ resourceTypes:
         description: "Internal server error"
   delete:
     description: Delete a user-tenant from member tenant. Deleting from the central tenant is forbidden.
+    queryParameters:
+      tenantId:
+        description: Filter by tenant id
+        type: string
+        example: sfs000
+        required: false
     responses:
       204:
         description: "Successful deletion"

--- a/src/main/java/org/folio/event/service/UserTenantService.java
+++ b/src/main/java/org/folio/event/service/UserTenantService.java
@@ -91,6 +91,7 @@ public class UserTenantService {
    * @throws IllegalStateException if deleting is not possible
    */
   public Future<Boolean> deleteMemberUserTenant(String tenantId, Vertx vertx) {
+    logger.info("deleteMemberUserTenant:: Deleting user-tenant record for tenant: '{}'", tenantId);
     PostgresClient pgClient = pgClientFactory.apply(vertx, tenantId);
     return pgClient.withConn(conn -> fetchFirstUserTenant(conn, tenantId)
       .compose(res -> {
@@ -118,6 +119,7 @@ public class UserTenantService {
    * @return future with true if records were deleted or false otherwise
    */
   public Future<Boolean> deleteCentralUserTenants(String centralTenantId, String tenantId, Vertx vertx) {
+    logger.info("deleteCentralUserTenants:: Deleting user-tenant records for tenant: '{}' from central tenant: '{}'", tenantId, centralTenantId);
     PostgresClient pgClient = pgClientFactory.apply(vertx, centralTenantId);
     return pgClient.withConn(conn -> tenantRepository.deleteUserTenants(conn, centralTenantId, tenantId));
   }

--- a/src/main/java/org/folio/event/service/UserTenantService.java
+++ b/src/main/java/org/folio/event/service/UserTenantService.java
@@ -108,6 +108,20 @@ public class UserTenantService {
       }));
   }
 
+  /**
+   * User-tenant table in central ECS tenant has all necessary records.
+   * This method deletes all record related to a specific tenant from user-tenant table in central ECS tenant.
+   *
+   * @param centralTenantId the central tenant id
+   * @param tenantId the tenant id
+   * @param vertx the vertx instance
+   * @return future with true if records were deleted or false otherwise
+   */
+  public Future<Boolean> deleteCentralUserTenants(String centralTenantId, String tenantId, Vertx vertx) {
+    PostgresClient pgClient = pgClientFactory.apply(vertx, centralTenantId);
+    return pgClient.withConn(conn -> tenantRepository.deleteUserTenants(conn, centralTenantId, tenantId));
+  }
+
   private Future<UserTenantCollection> fetchFirstUserTenant(Conn conn, String tenantId) {
     Criterion criterion = new Criterion().setLimit(new Limit(1)).setOffset(new Offset(0));
     return tenantRepository.fetchUserTenants(conn, tenantId, criterion);

--- a/src/main/java/org/folio/repository/UserTenantRepository.java
+++ b/src/main/java/org/folio/repository/UserTenantRepository.java
@@ -40,7 +40,7 @@ public class UserTenantRepository {
   private static final String INSERT_SQL = "INSERT INTO %s.%s (id, user_id, username, tenant_id, creation_date, central_tenant_id, email, mobile_phone_number, phone_number, barcode, external_system_id, consortium_id)" +
     " VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)";
   private static final String DELETE_SQL = "DELETE FROM %s.%s WHERE user_id = $1 AND tenant_id = $2";
-  private static final String DELETE_FOR_TENANT_SQL = "DELETE FROM %s.%s WHERE tenant_id = $2";
+  private static final String DELETE_FOR_TENANT_SQL = "DELETE FROM %s.%s WHERE tenant_id = $1";
   private static final String UPDATE_SQL = "UPDATE %s.%s SET username = $1, email = $2, mobile_phone_number = $3, phone_number = $4, barcode = $5, external_system_id = $6 WHERE user_id = $7";
   private static final String SELECT_USER_TENANTS = "WITH cte AS (SELECT count(*) AS total_count FROM %1$s.%2$s %3$s) " +
     "SELECT j.*, cte.* FROM %1$s.%2$s j LEFT JOIN cte ON true " +

--- a/src/main/java/org/folio/repository/UserTenantRepository.java
+++ b/src/main/java/org/folio/repository/UserTenantRepository.java
@@ -94,8 +94,8 @@ public class UserTenantRepository {
   }
 
   public Future<Boolean> deleteUserTenants(Conn conn, String centralTenantId, String tenantId) {
-    String query = String.format(DELETE_FOR_TENANT_SQL, convertToPsqlStandard(centralTenantId), USER_TENANT_TABLE_NAME);
-    Tuple queryParams = Tuple.of(tenantId);
+    var query = DELETE_FOR_TENANT_SQL.formatted(convertToPsqlStandard(centralTenantId), USER_TENANT_TABLE_NAME);
+    var queryParams = Tuple.of(tenantId);
     return conn.execute(query, queryParams)
       .map(resultSet -> resultSet.rowCount() > 0)
       .recover(throwable -> handleFailures(throwable, tenantId));

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -85,11 +85,11 @@ public class UserTenantsAPI implements UserTenants {
     String okapiTenantId = TenantTool.tenantId(okapiHeaders);
     deleteUserTenants(okapiTenantId, optionalTenantId, vertxContext.owner())
       .onSuccess(res -> {
-        logger.info("Record from member user-tenant has been deleted successfully. All http requests to this ECS tenant will be forbidden");
+        logger.info("Record(s) from user_tenant has been deleted successfully. For a member tenant, all http requests to it will be forbidden");
         asyncResultHandler.handle(succeededFuture(Response.status(204).build()));
       })
       .onFailure(cause -> {
-        logger.error("Could not delete member ECS user-tenant record", cause);
+        logger.error("Could not delete user_tenant record(s)", cause);
         asyncResultHandler.handle(succeededFuture(PostUserTenantsResponse.respond500WithTextPlain(cause.getMessage())));
       });
   }

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -2,7 +2,9 @@ package org.folio.rest.impl;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -79,9 +81,9 @@ public class UserTenantsAPI implements UserTenants {
   }
 
   @Override
-  public void deleteUserTenants(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void deleteUserTenants(String optionalTenantId, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     String okapiTenantId = TenantTool.tenantId(okapiHeaders);
-    userTenantService.deleteMemberUserTenant(okapiTenantId, vertxContext.owner())
+    deleteUserTenants(okapiTenantId, optionalTenantId, vertxContext.owner())
       .onSuccess(res -> {
         logger.info("Record from member user-tenant has been deleted successfully. All http requests to this ECS tenant will be forbidden");
         asyncResultHandler.handle(succeededFuture(Response.status(204).build()));
@@ -90,6 +92,25 @@ public class UserTenantsAPI implements UserTenants {
         logger.error("Could not delete member ECS user-tenant record", cause);
         asyncResultHandler.handle(succeededFuture(PostUserTenantsResponse.respond500WithTextPlain(cause.getMessage())));
       });
+  }
+
+  /**
+   * This method is used to delete user-tenant records from member tenant or central tenant table for two scenarios during ECS tenant deletion: <br/>
+   * 1. When we soft-delete a tenant, we need to delete a single record from the member tenant's user-tenant table. <br/>
+   * 2. When we hard-delete a tenant, we need to delete all records for this tenant from central tenant table. <br/>
+   * <br/>
+   * The <code>optionalTenantId</code> is an optional parameter, if it is not provided, then we assume that request was sent to the member tenant,
+   * and we need to delete a single record from user-tenant table, otherwise we need to delete all records for this tenant from central tenant table
+   *
+   * @param tenantId tenant id from request headers
+   * @param optionalTenantId optional tenant id
+   * @param vertx vertx instance
+   * @return future with boolean result
+   */
+  private Future<Boolean> deleteUserTenants(String tenantId, String optionalTenantId, Vertx vertx) {
+    return StringUtils.isBlank(optionalTenantId)
+      ? userTenantService.deleteMemberUserTenant(tenantId, vertx)
+      : userTenantService.deleteCentralUserTenants(tenantId, tenantId, vertx);
   }
 
   private void addWhereClauseArgumentsToCriterion(ArgumentsHolder argumentsHolder, String queryOp, Criterion criterion) {

--- a/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserTenantsAPI.java
@@ -110,7 +110,7 @@ public class UserTenantsAPI implements UserTenants {
   private Future<Boolean> deleteUserTenants(String tenantId, String optionalTenantId, Vertx vertx) {
     return StringUtils.isBlank(optionalTenantId)
       ? userTenantService.deleteMemberUserTenant(tenantId, vertx)
-      : userTenantService.deleteCentralUserTenants(tenantId, tenantId, vertx);
+      : userTenantService.deleteCentralUserTenants(tenantId, optionalTenantId, vertx);
   }
 
   private void addWhereClauseArgumentsToCriterion(ArgumentsHolder argumentsHolder, String queryOp, Criterion criterion) {

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -110,6 +110,22 @@ class UserTenantIT extends AbstractRestTestNoData {
   }
 
   @Test
+  void canDeleteFromCentralUserTenantTable() {
+    var initialCollection = userTenantClient.getAllUsersTenants();
+    var differentTenantRecordCount = initialCollection.getUserTenants().stream()
+      .filter(tenant -> !tenant.getTenantId().equals(TENANT_X))
+      .count();
+
+    Assertions.assertEquals(3, initialCollection.getTotalRecords());
+
+    String error = userTenantClient.deleteMemberUserTenantByTenantId(TENANT_X);
+    Assertions.assertTrue(StringUtils.isBlank(error));
+
+    var resultCollection = userTenantClient.getAllUsersTenants();
+    Assertions.assertEquals(differentTenantRecordCount, (long) resultCollection.getTotalRecords());
+  }
+
+  @Test
   void canUpdateUserTenant() {
     UserTenantCollection collection = userTenantClient.getAllUsersTenants();
     UserTenant userTenant = collection.getUserTenants().stream()

--- a/src/test/java/org/folio/rest/impl/UserTenantIT.java
+++ b/src/test/java/org/folio/rest/impl/UserTenantIT.java
@@ -119,6 +119,7 @@ class UserTenantIT extends AbstractRestTestNoData {
     Assertions.assertEquals(3, initialCollection.getTotalRecords());
 
     String error = userTenantClient.deleteMemberUserTenantByTenantId(TENANT_X);
+    awaitHandlingEvent(1);
     Assertions.assertTrue(StringUtils.isBlank(error));
 
     var resultCollection = userTenantClient.getAllUsersTenants();

--- a/src/test/java/org/folio/support/http/UserTenantClient.java
+++ b/src/test/java/org/folio/support/http/UserTenantClient.java
@@ -47,4 +47,13 @@ public class UserTenantClient {
      .then()
      .extract().asString();
   }
+
+  public String deleteMemberUserTenantByTenantId(String tenantId) {
+   return configuration.initialSpecification()
+     .param("tenantId", tenantId)
+     .when()
+     .delete()
+     .then()
+     .extract().asString();
+  }
 }


### PR DESCRIPTION
## Purpose
[[MODCONSKC-69] Add support for deleting related module's data for consortia tenant hard delete](https://folio-org.atlassian.net/browse/MODCONSKC-69)

## Approach
Extend user tenants endpoint with a new param `tenantId` to differentiate deleting records from member or central user_tenants table