### PR TITLE
Start testcontainers using withStartupAttempts(3)

### DIFF
--- a/src/test/java/org/folio/moduserstest/AbstractRestTest.java
+++ b/src/test/java/org/folio/moduserstest/AbstractRestTest.java
@@ -61,7 +61,8 @@ public abstract class AbstractRestTest {
   protected static Vertx vertx;
 
   private static final KafkaContainer kafkaContainer =
-    new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE_NAME));
+    new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE_NAME))
+    .withStartupAttempts(3);
 
   @SneakyThrows
   public static void beforeAll(Vertx vertx, VertxTestContext context, boolean hasData) {
@@ -97,7 +98,8 @@ public abstract class AbstractRestTest {
   private static final LocalStackContainer localStackContainer = new LocalStackContainer(
     DockerImageName.parse("localstack/localstack:s3-latest")
   )
-    .withServices(LocalStackContainer.Service.S3);
+    .withServices(LocalStackContainer.Service.S3)
+    .withStartupAttempts(3);
 
   @BeforeClass
   public static void setUpClass() {


### PR DESCRIPTION
## Purpose
Sometimes a build fails with
```
[ERROR]   ProxyRelationshipsIT>AbstractRestTestNoData.beforeAll:11->AbstractRestTest.beforeAll:77 » ContainerLaunch Container startup failed for image apache/kafka-native:3.8.0
[ERROR]   ReferenceAndSampleDataIT>AbstractRestTestWithData.beforeAll:11->AbstractRestTest.beforeAll:77 » ContainerLaunch Container startup failed for image apache/kafka-native:3.8.0
```

Examples:
* https://jenkins-aws.indexdata.com/job/folio-org/job/mod-users/job/MODUSERS-521/4/execution/node/42/log/
* https://jenkins-aws.indexdata.com/job/folio-org/job/mod-users/job/MODUSERS-521/3/execution/node/42/log/
* https://jenkins-aws.indexdata.com/job/folio-org/job/mod-users/job/MODUSERS-521/1/execution/node/42/log/
* https://jenkins-aws.indexdata.com/job/folio-org/job/mod-users/view/change-requests/job/PR-417/1/execution/node/42/log/
* https://jenkins-aws.indexdata.com/job/folio-org/job/mod-users/job/master/346/execution/node/43/log/
* https://jenkins-aws.indexdata.com/job/folio-org/job/mod-users/job/master/343/execution/node/43/log/

## Approach
Using .withStartupAttempts(3) may fix it by retrying multiple times.

#### TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.