### PR TITLE
MODUSERS-524 double import of testcontainers-bom

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "java.configuration.updateBuildConfiguration": "interactive"
+  "java.configuration.updateBuildConfiguration": "interactive",
+  "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-users
 
-Copyright (C) 2016-2023 The Open Library Foundation
+Copyright (C) 2016-2025 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
@@ -11,7 +11,7 @@ Module to provide central user management for FOLIO systems.
 
 ## Prerequisites
 
-* Java 11 JDK
+* Java 21 JDK
 * Maven 3.3.9
 
 ## Additional information

--- a/pom.xml
+++ b/pom.xml
@@ -132,13 +132,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers-bom</artifactId>
-      <version>1.19.1</version>
-      <type>pom</type>
-      <scope>import</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>


### PR DESCRIPTION
Fixes mvn reporting:
  
```
dependencies.dependency.scope' for org.testcontainers:testcontainers-bom:pom must
  be one of [provided, compile, runtime, test, system] but is 'import'. @ line 139, column 14
```

Specify java 21 and current year README.

The double import was introduced in commit 46b4ae38c199b11fcf8c2e84015a911e962b09a8
