### PR TITLE
MODUSERS-525 KAFKA_ENABLE option

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -691,6 +691,7 @@
       { "name": "DB_QUERYTIMEOUT", "value": "60000" },
       { "name": "DB_CHARSET", "value": "UTF-8" },
       { "name": "DB_MAXPOOLSIZE", "value": "5" },
+      { "name": "KAFKA_ENABLE", "value": "true" },
       { "name": "KAFKA_HOST", "value": "10.0.2.15"},
       { "name": "KAFKA_PORT", "value": "9092" },
       { "name": "AWS_URL", "value": "http://127.0.0.1:9000/" },

--- a/src/main/java/org/folio/event/KafkaConfigSingleton.java
+++ b/src/main/java/org/folio/event/KafkaConfigSingleton.java
@@ -9,6 +9,8 @@ public enum KafkaConfigSingleton {
 
   private final KafkaConfig kafkaConfig;
 
+  private final boolean enabled = Boolean.parseBoolean(getPropertyValue("KAFKA_ENABLED", "true"));
+
   KafkaConfigSingleton() {
     String envId = getPropertyValue("ENV", "folio");
     String kafkaPort = getPropertyValue("KAFKA_PORT", "9092");
@@ -29,6 +31,10 @@ public enum KafkaConfigSingleton {
 
   public KafkaConfig getKafkaConfig() {
     return kafkaConfig;
+  }
+
+  public boolean isKafkaEnabled() {
+    return enabled;
   }
 
   public static String getPropertyValue(String propertyName, String defaultValue) {

--- a/src/main/java/org/folio/event/service/UserEventProducer.java
+++ b/src/main/java/org/folio/event/service/UserEventProducer.java
@@ -28,18 +28,24 @@ public class UserEventProducer {
 
   private final KafkaConfig kafkaConfig;
 
+  private final boolean enabled;
+
   public UserEventProducer() {
-    this(KafkaConfigSingleton.INSTANCE.getKafkaConfig());
+    this(KafkaConfigSingleton.INSTANCE.getKafkaConfig(), KafkaConfigSingleton.INSTANCE.isKafkaEnabled());
   }
 
-  public UserEventProducer(KafkaConfig kafkaConfig) {
+  public UserEventProducer(KafkaConfig kafkaConfig, boolean enabled) {
     this.kafkaConfig = kafkaConfig;
+    this.enabled = enabled;
   }
 
   public Future<Boolean> sendUserEvent(User user,
                                        boolean isPersonalDataChanged,
                                        UserEvent.Action eventAction,
                                        Map<String, String> okapiHeaders) {
+    if (!enabled) {
+      return Future.succeededFuture(false);
+    }
     String tenantId = okapiHeaders.get("x-okapi-tenant");
     UserEvent event = getUserEvent(user, tenantId, isPersonalDataChanged, eventAction);
 

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -38,6 +38,10 @@ public class InitAPIs implements InitAPI {
   }
 
   private Future<?> deployConsumersVerticles(Vertx vertx) {
+    if (!org.folio.event.KafkaConfigSingleton.INSTANCE.isKafkaEnabled()) {
+      return Future.succeededFuture();
+    }
+
     int usersConsortiumConsumerInstancesNumber = Integer.parseInt(getPropertyValue("users.consortium.kafka.consumer.instancesNumber", "1"));
 
     Promise<String> consortiumCreateEventConsumer = Promise.promise();


### PR DESCRIPTION
Set to "true" by default to keep existing behavior.

The purpose of this PR is to allow mod-users to operate without KAFKA.
Indeed it is used for consortia messages for users. If that's not in use,
KAFKA is not needed.
