### PR TITLE
MODUSERS-531: Add displayInAccordion for custom fields

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -178,7 +178,7 @@
     },
     {
       "id": "custom-fields",
-      "version": "3.0",
+      "version": "3.1",
       "interfaceType" : "multiple",
       "handlers": [
         {

--- a/pom.xml
+++ b/pom.xml
@@ -588,7 +588,7 @@
     <generate_routing_context>/users</generate_routing_context>
     <junit.version>5.12.0</junit.version>
     <folio-service-tools.version>5.0.0</folio-service-tools.version>
-    <folio-custom-fields.version>2.3.1</folio-custom-fields.version>
+    <folio-custom-fields.version>3.0.0-SNAPSHOT</folio-custom-fields.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <java.version>21</java.version>
     <aspectj.version>1.9.22.1</aspectj.version>

--- a/src/main/java/org/folio/service/impl/RecordServiceImpl.java
+++ b/src/main/java/org/folio/service/impl/RecordServiceImpl.java
@@ -13,6 +13,7 @@ import org.folio.rest.jaxrs.model.CustomFieldOptionStatistic;
 import org.folio.rest.jaxrs.model.CustomFieldStatistic;
 import org.folio.rest.jaxrs.model.CustomFields;
 import org.folio.rest.jaxrs.model.User;
+import org.folio.rest.persist.Conn;
 import org.folio.service.RecordService;
 
 import io.vertx.core.Future;
@@ -50,6 +51,11 @@ public class RecordServiceImpl implements RecordService {
       .onSuccess(users -> LOG.info("The number of users found with the given field: {}", users.size()));
 
     return related.compose(users -> removeCustomFieldFromUsers(users, field, tenantId));
+  }
+
+  @Override
+  public Future<Void> deleteAllValues(Conn conn, CustomField customField, String s) {
+    return Future.failedFuture(new UnsupportedOperationException("Not supported yet."));
   }
 
   @Override

--- a/src/test/java/org/folio/moduserstest/CustomFieldIT.java
+++ b/src/test/java/org/folio/moduserstest/CustomFieldIT.java
@@ -47,14 +47,17 @@ public class CustomFieldIT extends AbstractRestTestNoData {
       .username("admin-user")
       .build());
 
-    customFieldsClient.createCustomField(
+    var createdCustomField = customFieldsClient.createCustomField(
       CustomField.builder()
         .name("Hobbies")
         .helpText("Describe hobbies")
         .entityType("user")
         .type("TEXTBOX_SHORT")
         .order(1)
+        .displayInAccordion("fee_fines")
         .build(), maintainingUser);
+
+    assertThat(createdCustomField.getDisplayInAccordion(), is("fee_fines"));
 
     final var createdUser = usersClient.attemptToCreateUser(User.builder()
       .username("some-user")

--- a/src/test/java/org/folio/support/CustomField.java
+++ b/src/test/java/org/folio/support/CustomField.java
@@ -21,4 +21,5 @@ public class CustomField {
   String entityType;
   String type;
   Integer order;
+  String displayInAccordion;
 }


### PR DESCRIPTION
Jira issue: https://folio-org.atlassian.net/browse/MODUSERS-531

## Purpose
Add the ability to add, view, and update a `displayInAccordion` custom field value

## Approach
- folio-custom-fields library version increased
- Code adjusted to the changes of the new RecordService interface
- Unit and integration tests adjusted

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
