### PR TITLE
MODUSERS-514: Prevent Deletion of All Users in a Tenant

### DIFF
--- a/ramls/users.raml
+++ b/ramls/users.raml
@@ -46,7 +46,7 @@ resourceTypes:
   delete:
     description: Delete a collection of users selected by a CQL query; this doesn't delete proxyFor records that reference them
     is: [
-      searchable: {description: "CQL query", example: "active==false"}
+      searchable: {description: "CQL to select users to delete, use cql.allRecords=1 to delete all", example: "active==false"}
     ]
     responses:
       204:
@@ -55,7 +55,7 @@ resourceTypes:
         description: "Bad request"
         body:
           text/plain:
-            example: "Invalid CQL syntax"
+            example: "Expected CQL but query parameter is empty"
       500:
         description: "Internal server error, e.g. due to misconfiguration"
         body:

--- a/src/main/java/org/folio/rest/impl/UsersAPI.java
+++ b/src/main/java/org/folio/rest/impl/UsersAPI.java
@@ -496,6 +496,11 @@ public class UsersAPI implements Users {
       Context vertxContext) {
 
     try {
+      if (StringUtils.isBlank(query)) {
+        var msg = "Expected CQL but query parameter is empty";
+        asyncResultHandler.handle(Future.succeededFuture(DeleteUsersResponse.respond400WithTextPlain(msg)));
+        return;
+      }
       CQLWrapper wrapper = getCQL(query, -1, -1);
       PgUtil.postgresClient(vertxContext, okapiHeaders).withTrans(conn -> conn.execute(createDeleteQuery(wrapper, okapiHeaders))
         .compose(rows -> {

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -670,6 +670,13 @@ class UsersAPIIT extends AbstractRestTestNoData {
   }
 
   @Test
+  void cannotDeleteWithEmptyCQL() {
+    usersClient.attemptToDeleteUsers(" ")
+      .statusCode(400)
+      .body(is("Expected CQL but query parameter is empty"));
+  }
+
+  @Test
   void createJPGProfilePictureInDb() {
     configurationClient.updateConfiguration(new Config()
       .withConfigName("PROFILE_PICTURE_CONFIG")

--- a/src/test/java/org/folio/support/http/RestAssuredCollectionApiClient.java
+++ b/src/test/java/org/folio/support/http/RestAssuredCollectionApiClient.java
@@ -98,12 +98,17 @@ public class RestAssuredCollectionApiClient<Record, Collection> {
   }
 
   void deleteRecords(String cqlQuery) {
-    initialSpecification()
+    attemptToDeleteRecords(cqlQuery)
+      .statusCode(SC_NO_CONTENT);
+  }
+
+
+  ValidatableResponse attemptToDeleteRecords(String cqlQuery) {
+    return initialSpecification()
       .when()
       .queryParam("query", cqlQuery)
       .delete()
-      .then()
-      .statusCode(SC_NO_CONTENT);
+      .then();
   }
 
   RequestSpecification initialSpecification() {

--- a/src/test/java/org/folio/support/http/UsersClient.java
+++ b/src/test/java/org/folio/support/http/UsersClient.java
@@ -76,6 +76,10 @@ public class UsersClient {
     client.deleteRecords(cqlQuery);
   }
 
+  public ValidatableResponse attemptToDeleteUsers(String cqlQuery) {
+    return client.attemptToDeleteRecords(cqlQuery);
+  }
+
   public void deleteAllUsers() {
     deleteUsers("cql.allRecords=1");
   }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUSERS-514

## Purpose
This prevent unintended deletion of all users.

## Approach
Require a non-empty query parameter.

See https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/r/instance-storage.html#instance_storage_instances_delete how FOLIO’s APIs require a non-empty query parameter.

The missing check is a bug that needs to be fixed.

#### TODOS and Open Questions
- [x] Check logging

## Learning
DELETE by CQL APIs should reject a missing or empty CQL parameter.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues