### PR TITLE
MODUSERS-549: Fix metadata in Kafka user update events

### DIFF
--- a/src/main/java/org/folio/service/UsersService.java
+++ b/src/main/java/org/folio/service/UsersService.java
@@ -28,7 +28,7 @@ public class UsersService {
           String errorMsg = String.format("User with id %s was not found", user.getId());
           return Future.failedFuture(new HttpException(Response.Status.NOT_FOUND.getStatusCode(), errorMsg));
         }
-        return Future.succeededFuture(user);
+        return conn.getById(TABLE_NAME_USERS, user.getId(), User.class);
       })
       .onSuccess(x -> logger.info("updateUser complete, userId={}", user.getId()))
       .onFailure(e -> logger.error("updateUser failed, userId={}", user.getId(), e));

--- a/src/test/java/org/folio/rest/impl/UsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/UsersAPIIT.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.time.ZonedDateTime;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -455,6 +456,60 @@ class UsersAPIIT extends AbstractRestTestNoData {
           .build())
       .statusCode(is(400))
       .body(is("This barcode has already been taken"));
+  }
+
+  @Test
+  void updateUserPublishesCorrectMetadataInKafkaEvent() {
+    final var createdUser = usersClient.createUser(User.builder()
+      .username("kafka-test-user")
+      .barcode("12345")
+      .active(true)
+      .personal(Personal.builder().lastName("KafkaTest").firstName("User").build())
+      .build());
+
+    await().until(() -> kafkaConsumer.getUsersEvents(createdUser.getId()).size(), is(1));
+
+    final var originalMetadata = createdUser.getMetadata();
+    final var originalCreatedDate = originalMetadata.getCreatedDate();
+    final var originalUpdatedDate = originalMetadata.getUpdatedDate();
+    final var originalCreatedBy = originalMetadata.getCreatedByUserId();
+
+    usersClient.attemptToUpdateUser(User.builder()
+        .id(createdUser.getId())
+        .username("kafka-test-user-updated")
+        .barcode("67890")
+        .active(false)
+        .personal(Personal.builder().lastName("KafkaTest").firstName("UpdatedUser").build())
+        .build())
+      .statusCode(is(204));
+
+    await().until(() -> kafkaConsumer.getUsersEvents(createdUser.getId()).size(), is(2));
+
+    awaitUntilAsserted(() -> {
+      final var updateEvent = kafkaConsumer.getLastUserEvent(createdUser.getId());
+      final var data = updateEvent.value().getJsonObject("data");
+
+      final var oldUser = data.getJsonObject("old");
+      assertThat(oldUser.getString("username"), is("kafka-test-user"));
+      assertThat(oldUser.getString("barcode"), is("12345"));
+      assertThat(oldUser.getBoolean("active"), is(true));
+      assertThat(oldUser.getJsonObject("personal").getString("firstName"), is("User"));
+
+      final var newUser = data.getJsonObject("new");
+      assertThat(newUser.getString("username"), is("kafka-test-user-updated"));
+      assertThat(newUser.getString("barcode"), is("67890"));
+      assertThat(newUser.getBoolean("active"), is(false));
+      assertThat(newUser.getJsonObject("personal").getString("firstName"), is("UpdatedUser"));
+
+      final var newUserMetadata = newUser.getJsonObject("metadata");
+      final var createdDateInEvent = ZonedDateTime.parse(newUserMetadata.getString("createdDate"));
+      final var createdByInEvent = newUserMetadata.getString("createdByUserId");
+      final var updatedDateInEvent = ZonedDateTime.parse(newUserMetadata.getString("updatedDate"));
+
+      assertThat(createdDateInEvent, is(originalCreatedDate));
+      assertThat(updatedDateInEvent.isAfter(originalUpdatedDate), is(true));
+      assertThat(createdByInEvent, is(originalCreatedBy));
+    });
   }
 
   @Test

--- a/src/test/java/org/folio/support/Metadata.java
+++ b/src/test/java/org/folio/support/Metadata.java
@@ -14,5 +14,6 @@ import lombok.extern.jackson.Jacksonized;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Metadata {
   ZonedDateTime createdDate;
+  String createdByUserId;
   ZonedDateTime updatedDate;
 }


### PR DESCRIPTION
Kafka update events now reflect the actual database state after triggers execute. UsersService.updateUser() re-fetches the user from the database to ensure metadata fields (createdDate, createdByUserId) are preserved.

Fixes https://folio-org.atlassian.net/browse/MODUSERS-549

## Purpose

When updating a user via `PUT /users/{id}`, the Kafka event's `newValue` contained incorrect metadata fields:
- `metadata.createdDate` was set to update time instead of original creation time
- `metadata.createdByUserId` was set to current user instead of original creator

While a database trigger correctly restores these fields in the database, the Kafka event was being published using the pre-trigger object state, causing:

- **Kafka Event Inconsistency**: Consumers receive incorrect metadata that doesn't match actual database state
- **Audit Trail Corruption**: Features like version history show false diffs for metadata fields that should never change
- **Data Trust Issues**: Kafka events show system users were created by regular users

https://folio-org.atlassian.net/browse/MODUSERS-549

## Approach

Modified `UsersService.updateUser()` to re-fetch the user record from the database after the update completes:

1. Perform the database update as usual
2. After the update succeeds, re-fetch the user record to capture the post-trigger state
3. Use the freshly fetched record for Kafka event publication

This ensures the Kafka event reflects the actual database state, including any modifications made by database triggers. The approach is robust and handles any future triggers that might modify the data.
