### PR TITLE
MODUSERS-580 Upgrade dependencies for Kafka v4.2 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <folio-module-descriptor-validator.version>1.0.1</folio-module-descriptor-validator.version>
     <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
     <aspectj-maven-plugin.version>1.14.1</aspectj-maven-plugin.version>
-    <folio-kafka-wrapper.version>4.0.0</folio-kafka-wrapper.version>
+    <folio-kafka-wrapper.version>4.1.0-SNAPSHOT</folio-kafka-wrapper.version>
   </properties>
 
   <licenses>

--- a/src/test/java/org/folio/extensions/KafkaContainerExtension.java
+++ b/src/test/java/org/folio/extensions/KafkaContainerExtension.java
@@ -27,10 +27,8 @@ import org.folio.support.TestConstants;
 
 public class KafkaContainerExtension implements BeforeAllCallback, AfterAllCallback {
 
+  public static final String KAFKA_IMAGE_ID = "apache/kafka-native:4.2.1";
   private static final Logger LOG = LoggerFactory.getLogger(KafkaContainerExtension.class);
-
-  public static final String KAFKA_IMAGE_ID = "apache/kafka-native:3.8.0";
-
   public static final KafkaContainer KAFKA_CONTAINER =
     new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE_ID))
       .withStartupAttempts(3);


### PR DESCRIPTION
## Purpose
Upgrade dependencies for Kafka v4.2 compatibility
Jira: https://folio-org.atlassian.net/browse/MODUSERS-580

## Approach
- Update `folio-kafka-wrapper` to `v4.1.0-SNAPSHOT`
- Update Kafka container version for integration testing to `v4.2.1`


