### PR TITLE
MODUSERS-585 Remove usage of deprecated folio-service-tools-test lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
     <!-- Folio dependencies properties -->
     <folio-s3-client.version>3.0.1</folio-s3-client.version>
     <folio-custom-fields.version>4.0.0-SNAPSHOT</folio-custom-fields.version>
-    <folio-service-tools.version>6.0.0</folio-service-tools.version>
     <raml-module-builder.version>36.0.0</raml-module-builder.version>
 
     <!-- Test Dependency Versions -->
@@ -36,6 +35,7 @@
     <junit-bom.version>6.1.0</junit-bom.version>
     <mockito-bom.version>5.23.0</mockito-bom.version>
     <testcontainers-bom.version>2.0.5</testcontainers-bom.version>
+    <wiremock.version>3.13.2</wiremock.version>
 
     <!-- Plugin Versions -->
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
@@ -193,11 +193,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
        <groupId>io.vertx</groupId>
        <artifactId>vertx-unit</artifactId>
        <scope>test</scope>
@@ -238,12 +233,6 @@
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
-      <artifactId>folio-service-tools-test</artifactId>
-      <version>${folio-service-tools.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
       <artifactId>testing</artifactId>
       <version>${raml-module-builder.version}</version>
       <scope>test</scope>
@@ -275,6 +264,18 @@
       <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>${wiremock.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sf.jopt-simple</groupId>
+          <artifactId>jopt-simple</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -284,6 +285,13 @@
         <configuration>
           <release>${java.version}</release>
           <encoding>UTF-8</encoding>
+          <annotationProcessorPaths>
+          <path>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+          </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/java/org/folio/moduserstest/AbstractRestTest.java
+++ b/src/test/java/org/folio/moduserstest/AbstractRestTest.java
@@ -5,14 +5,16 @@ import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofMinutes;
 import static org.folio.extensions.KafkaContainerExtension.createTopics;
 import static org.folio.extensions.KafkaContainerExtension.getTopicName;
+import static org.folio.repository.CustomFieldsConstants.JSONB_COLUMN;
 import static org.folio.support.TestConstants.ENV;
 import static org.folio.support.TestConstants.TENANT_NAME;
-import static org.folio.test.util.TestUtil.readFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -21,6 +23,12 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.io.FileUtils;
+import org.folio.cql2pgjson.CQL2PgJSON;
+import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.cql.CQLWrapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -112,6 +120,26 @@ public abstract class AbstractRestTest {
     } catch (IOException | URISyntaxException e) {
       Assertions.fail(e.getMessage());
       return null;
+    }
+  }
+
+  protected static String readFile(String filename) throws IOException, URISyntaxException {
+    return FileUtils.readFileToString(getFile(filename), StandardCharsets.UTF_8);
+  }
+
+  protected static File getFile(String filename) throws URISyntaxException {
+    return new File(AbstractRestTest.class.getClassLoader().getResource(filename).toURI());
+  }
+
+  protected static void deleteFromTable(Vertx vertx, String tableName, String tenantId) {
+    try {
+      CompletableFuture<Void> future = new CompletableFuture<>();
+      PostgresClient.getInstance(vertx, tenantId).delete(tableName,
+        new CQLWrapper(new CQL2PgJSON(JSONB_COLUMN), "cql.allRecords=1"),
+        event -> future.complete(null));
+      future.join();
+    } catch (FieldException e) {
+      throw new IllegalStateException(e);
     }
   }
 }

--- a/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
+++ b/src/test/java/org/folio/rest/impl/CustomFieldTestBase.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 
 import io.restassured.http.Header;
+import org.folio.okapi.common.XOkapiHeaders;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,12 +16,11 @@ import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.support.User;
 import org.folio.support.http.CustomFieldsClient;
 import org.folio.support.http.UsersClient;
-import org.folio.test.util.TokenTestUtil;
 
 class CustomFieldTestBase extends AbstractRestTestNoData {
 
   protected static final String USER_ID = "88888888-8888-4888-8888-888888888888";
-  protected static final Header FAKE_TOKEN = TokenTestUtil.createTokenHeader("mockuser8", USER_ID);
+  protected static final Header FAKE_TOKEN = new Header(XOkapiHeaders.TOKEN, "fake-token");
   protected static final Header FAKE_USER_ID = new Header(OKAPI_USERID_HEADER, USER_ID);
 
   private static final String USER_JSON_PATH = "users/user8.json";

--- a/src/test/java/org/folio/rest/impl/DepartmentsAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/DepartmentsAPIIT.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.UUID;
 
 import io.restassured.http.Header;
+import org.folio.okapi.common.XOkapiHeaders;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,14 +37,13 @@ import org.folio.support.User;
 import org.folio.support.http.DepartmentsClient;
 import org.folio.support.http.UsersClient;
 import org.folio.support.tags.IntegrationTest;
-import org.folio.test.util.TokenTestUtil;
 
 @IntegrationTest
 class DepartmentsAPIIT extends AbstractRestTestNoData {
 
   private static final String USER_JSON_PATH = "users/user8.json";
   private static final String USER_ID = "88888888-8888-4888-8888-888888888888";
-  private static final Header FAKE_TOKEN = TokenTestUtil.createTokenHeader("mockuser8", USER_ID);
+  private static final Header FAKE_TOKEN = new Header(XOkapiHeaders.TOKEN, "fake-token");
   private static final Header FAKE_USER_ID = new Header(OKAPI_USERID_HEADER, USER_ID);
 
   private static UsersClient usersClient;

--- a/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/PatronPinAPIIT.java
@@ -19,7 +19,6 @@ import org.folio.support.User;
 import org.folio.support.http.PatronPinClient;
 import org.folio.support.http.UsersClient;
 import org.folio.support.tags.IntegrationTest;
-import org.folio.test.util.DBTestUtil;
 
 @IntegrationTest
 class PatronPinAPIIT extends AbstractRestTestNoData {
@@ -104,7 +103,7 @@ class PatronPinAPIIT extends AbstractRestTestNoData {
   }
 
   private void deleteAllPatronPins(Vertx vertx) {
-    DBTestUtil.deleteFromTable(vertx, "patronpin", TENANT_NAME);
+    deleteFromTable(vertx, "patronpin", TENANT_NAME);
   }
 
 }

--- a/src/test/java/org/folio/rest/impl/StagingUsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/StagingUsersAPIIT.java
@@ -53,7 +53,6 @@ import org.folio.support.http.GroupsClient;
 import org.folio.support.http.StagingUsersClient;
 import org.folio.support.http.UsersClient;
 import org.folio.support.tags.IntegrationTest;
-import org.folio.test.util.DBTestUtil;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
@@ -587,7 +586,7 @@ class StagingUsersAPIIT extends AbstractRestTestNoData {
   }
 
   private void deleteAllStagingUsers(Vertx vertx) {
-    DBTestUtil.deleteFromTable(vertx, "staging_users", TENANT_NAME);
+    deleteFromTable(vertx, "staging_users", TENANT_NAME);
   }
 
   private StagingUser createStagingUser(StagingUser stagingUserToCreate) {

--- a/src/test/java/org/folio/support/http/CustomFieldsClient.java
+++ b/src/test/java/org/folio/support/http/CustomFieldsClient.java
@@ -4,7 +4,6 @@ import static io.restassured.http.ContentType.JSON;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
-import static org.folio.test.util.TokenTestUtil.generateToken;
 
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
@@ -185,7 +184,7 @@ public class CustomFieldsClient {
     }
 
     return new Headers(
-      new Header("X-Okapi-Token", generateToken(user.getUsername(), user.getId())),
+      new Header("X-Okapi-Token", "fake-token"),
       new Header("X-Okapi-User-Id", user.getId())
     );
   }

--- a/src/test/java/org/folio/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/support/matchers/DomainEventAssertions.java
@@ -10,8 +10,8 @@ import static org.folio.support.TestConstants.TENANT_NAME;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.time.Duration;
 import java.util.List;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODQM-3
 -->
Remove usage of deprecated folio-service-tools-test lib

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- delete depenency
- create methods to read file and clean db table that was previously located in the lib
- remove junit-vintage dependency -> no more junit4 in classpath
- add wiremock dependency that was previously transitive

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
