### PR TITLE
[MODUSERS-586] Add preferredContactTypeIds field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+## 19.7.0 IN PROGRESS
+
+### New APIs versions
+* Provides `users v16.5`
+
+* **Deprecated** users' `personal`->`preferredContactTypeId` field in favor of an array `personal`->`preferredContactTypeIds` ([MODUSERS-586](https://folio-org.atlassian.net/browse/MODUSERS-586))
+
 ## 19.6.0 2026-04-15
 
 ### New APIs versions

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -10,7 +10,7 @@
   "provides": [
     {
       "id": "users",
-      "version": "16.4",
+      "version": "16.5",
       "handlers" : [
         {
           "methods": [ "GET" ],

--- a/ramls/userdata.json
+++ b/ramls/userdata.json
@@ -148,8 +148,15 @@
           }
         },
         "preferredContactTypeId": {
-          "description": "Id of user's preferred contact type like Email, Mail or Text Message, see /addresstypes API",
+          "description": "(Deprecated) ID of user's preferred contact type like Email, Mail, or Text Message  (see ui-users contactTypes.js)",
           "type": "string"
+        },
+        "preferredContactTypeIds": {
+          "description": "IDs of user's preferred contact types like Email, Mail, or Text Message (see ui-users contactTypes.js)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "profilePictureLink": {
           "description": "Link to the profile picture, or only the id of the /users/profile-picture entry",

--- a/ramls/users.raml
+++ b/ramls/users.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Users
-version: v16.1
+version: v16.5
 baseUri: http://github.com/org/folio/mod-users
 
 documentation:

--- a/src/main/java/org/folio/service/impl/StagingUserService.java
+++ b/src/main/java/org/folio/service/impl/StagingUserService.java
@@ -282,7 +282,7 @@ public class StagingUserService {
       personal.withEmail(contactInfo.getEmail())
         .withPhone(contactInfo.getPhone())
         .withMobilePhone(contactInfo.getMobilePhone())
-        .withPreferredContactTypeId(CONTACT_TYPE_EMAIL_ID);
+        .withPreferredContactTypeIds(List.of(CONTACT_TYPE_EMAIL_ID));
     }
   }
 

--- a/src/main/resources/sample-data/gen-folio-users
+++ b/src/main/resources/sample-data/gen-folio-users
@@ -78,7 +78,7 @@ for (my $i = $start; $i < $users + $start; $i++) {
                            email => $faker->email(),
                            phone => $faker->phone_number(),
                            dateOfBirth => "$birth_year-" . sprintf("%02d",$birth_month) . '-' . sprintf("%02d",$birth_day),
-                           preferredContactTypeId => $contacts[int(rand(5))],
+                           preferredContactTypeIds => [$contacts[int(rand(5))]],
                            addresses => [
                                          {
                                           countryId => 'US',

--- a/src/main/resources/templates/db_scripts/migrate_preferred_contact_id_to_array.sql
+++ b/src/main/resources/templates/db_scripts/migrate_preferred_contact_id_to_array.sql
@@ -1,0 +1,10 @@
+UPDATE users
+SET jsonb = jsonb_set(
+	jsonb,
+	'{personal,preferredContactTypeIds}',
+	jsonb_build_array(jsonb->'personal'->'preferredContactTypeId'),
+	true
+)
+WHERE jsonb->'personal' ? 'preferredContactTypeId'
+	AND jsonb->'personal'->'preferredContactTypeId' IS NOT NULL
+	AND jsonb->'personal'->'preferredContactTypeId' <> 'null'::jsonb;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -2,6 +2,11 @@
   "scripts" : [
     {
       "run": "after",
+      "snippetPath": "migrate_preferred_contact_id_to_array.sql",
+      "fromModuleVersion": "19.7.0"
+    },
+    {
+      "run": "after",
       "snippetPath": "create_custom_fields_table.sql",
       "fromModuleVersion": "19.3.0"
     },

--- a/src/test/java/org/folio/rest/impl/StagingUsersAPIIT.java
+++ b/src/test/java/org/folio/rest/impl/StagingUsersAPIIT.java
@@ -526,7 +526,7 @@ class StagingUsersAPIIT extends AbstractRestTestNoData {
         .middleName("jj")
         .lastName("brockhurst")
         .email("folio@folio.com")
-        .preferredContactTypeId("003")
+        .preferredContactTypeIds(List.of("003"))
         .phone("1234")
         .mobilePhone("4321")
         .addresses(addressList)
@@ -545,7 +545,7 @@ class StagingUsersAPIIT extends AbstractRestTestNoData {
     assertEquals("folio@folio.com", personal.getEmail());
     assertEquals("1234", personal.getPhone());
     assertEquals("4321", personal.getMobilePhone());
-    assertEquals("003", personal.getPreferredContactTypeId());
+    assertEquals(List.of("003"), personal.getPreferredContactTypeIds());
     assertEquals(addressList.size(), personal.getAddresses().size());
     assertEquals(Set.of(PreferredEmailCommunication.SUPPORT), createdUser.getPreferredEmailCommunication());
     return userToCreate;
@@ -615,7 +615,7 @@ class StagingUsersAPIIT extends AbstractRestTestNoData {
     assertEquals(stagingUser.getExternalSystemId(), user.getExternalSystemId());
     assertEquals(stagingContactInfo.getPhone(), userPersonal.getPhone());
     assertEquals(stagingContactInfo.getMobilePhone(), userPersonal.getMobilePhone());
-    assertEquals(CONTACT_TYPE_EMAIL_ID, userPersonal.getPreferredContactTypeId(), "user should always have 002 as its contact type");
+    assertEquals(List.of(CONTACT_TYPE_EMAIL_ID), userPersonal.getPreferredContactTypeIds(), "user should always have 002 as its only preferred contact type");
     var address = fetchPrimaryAddressFromUser(user);
     assertNotNull(address, "User should have a primary address");
     assertEquals(stagingAddressInfo.getAddressLine0(), address.getAddressLine1());

--- a/src/test/java/org/folio/support/Personal.java
+++ b/src/test/java/org/folio/support/Personal.java
@@ -23,6 +23,6 @@ public class Personal {
   String email;
   String phone;
   String mobilePhone;
-  String preferredContactTypeId;
+  List<String> preferredContactTypeIds;
   String profilePictureLink;
 }


### PR DESCRIPTION
# [Jira MODUSERS-586](https://folio-org.atlassian.net/browse/MODUSERS-586)

[UIU-3553](https://folio-org.atlassian.net/browse/UIU-3553) exists to update `ui-users` to use this new field.

## Purpose
As a library administrator or patron,
I want to specify multiple preferred contact types (e.g., Email, Text, Phone),
So that my institution can reach me through any of my preferred communication channels without needing to guess which single method I prefer.

Currently, users can only select a single preferred contact type via the `preferredContactTypeId` field. This limitation prevents users from indicating that they're equally comfortable receiving communications via multiple channels (e.g., both Email and Text Message). This PR extends the system to support multiple preferred contact types, enabling more flexible and effective patron communication strategies.

## Approach
- Add a new property
- Update docs for the old property
- Add a migration script to set `preferredContactTypeIds` = `[old preferredContactTypeId]` for existing users
- Retain `preferredContactTypeId` for legacy use with plans for future removal

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.